### PR TITLE
Add markdown "logo" metadata image to the navigation bar

### DIFF
--- a/src/elm/Lia/View.elm
+++ b/src/elm/Lia/View.elm
@@ -123,7 +123,8 @@ view_nav section_active mode lang image_url speaking state =
     Html.nav [ Attr.class "lia-toolbar" ]
         [ Html.map UpdateSettings <| Settings.toggle_button_toc lang
         , navButton "home" "index" "4px" Home
-        , logo image_url
+        , logo image_url "4px"
+        , Html.span [ Attr.class "lia-spacer" ] []
         , navButton "navigate_before" (Trans.basePrev lang) "" PrevSection
         , Html.span [ Attr.class "lia-labeled lia-left" ]
             [ Html.span
@@ -149,12 +150,12 @@ view_nav section_active mode lang image_url speaking state =
         , Html.map UpdateSettings <| Settings.switch_button_mode lang mode
         ]
 
-logo : String -> Html Msg
-logo image_url =
-    Html.span
-        [ Attr.class "lia-spacer"
-        , Attr.style "background-image" ("url('" ++ image_url ++ "')")
-        , Attr.style "background-repeat" "no-repeat"
-        , Attr.style "background-attachment" "fixed"
-        , Attr.style "margin" "2px"]
+logo : String -> String -> Html Msg
+logo image_url margin =
+    Html.img
+        [ Attr.src image_url
+        , Attr.class "lia-logo lia-left"
+        , Attr.style "margin-left" margin
+        , Attr.style "padding" "2px"
+        ]
         []

--- a/src/elm/Lia/View.elm
+++ b/src/elm/Lia/View.elm
@@ -65,7 +65,7 @@ view_article screen model =
                         model.section_active
                         model.settings.mode
                         model.translation
-                        model.url
+                        model.definition.logo
                         model.settings.speaking
                 , Html.map UpdateMarkdown <|
                     Markdown.view
@@ -119,11 +119,11 @@ navButton str title margin msg =
 
 
 view_nav : Int -> Mode -> Lang -> String -> Bool -> String -> Html Msg
-view_nav section_active mode lang base speaking state =
+view_nav section_active mode lang image_url speaking state =
     Html.nav [ Attr.class "lia-toolbar" ]
         [ Html.map UpdateSettings <| Settings.toggle_button_toc lang
         , navButton "home" "index" "4px" Home
-        , Html.span [ Attr.class "lia-spacer" ] []
+        , logo image_url
         , navButton "navigate_before" (Trans.basePrev lang) "" PrevSection
         , Html.span [ Attr.class "lia-labeled lia-left" ]
             [ Html.span
@@ -148,3 +148,13 @@ view_nav section_active mode lang base speaking state =
         , Html.span [ Attr.class "lia-spacer" ] []
         , Html.map UpdateSettings <| Settings.switch_button_mode lang mode
         ]
+
+logo : String -> Html Msg
+logo image_url =
+    Html.span
+        [ Attr.class "lia-spacer"
+        , Attr.style "background-image" ("url('" ++ image_url ++ "')")
+        , Attr.style "background-repeat" "no-repeat"
+        , Attr.style "background-attachment" "fixed"
+        , Attr.style "margin" "2px"]
+        []

--- a/src/scss/_controls.scss
+++ b/src/scss/_controls.scss
@@ -690,6 +690,11 @@
             }
         }
 
+        .lia-logo {
+            background: transparent;
+            max-width: 10%;
+        }
+
         .lia-left {
             order: 1;
         }


### PR DESCRIPTION
I've replaced an unused argument to `view_nav`.

I think to really address #1 I need to extract out a `Theme` type and extend the model with that `Theme`.