### PR TITLE
added arrow keys for navigation as long as a page element has focus

### DIFF
--- a/src/elm/Lia/Update.elm
+++ b/src/elm/Lia/Update.elm
@@ -1,5 +1,6 @@
 module Lia.Update exposing
     ( Msg(..)
+    , key_decoder
     , get_active_section
     , send
     , subscriptions
@@ -44,12 +45,29 @@ type Msg
     | UpdateMarkdown Markdown.Msg
     | Handle Event
     | Home
+    | KeyPressIgnored
 
 
 send : Int -> List ( String, JE.Value ) -> List Event
 send idx events =
     events
         |> List.map (\( name, json ) -> Event name idx json)
+
+
+key_to_message : String -> (Msg, Bool)
+key_to_message s =
+   case s of
+      "ArrowLeft" -> (PrevSection, True)
+
+      "ArrowRight" -> (NextSection, True)
+
+      _ -> (KeyPressIgnored, False)
+
+
+key_decoder : JD.Decoder (Msg, Bool)
+key_decoder =
+   JD.field "key" JD.string
+      |> JD.map key_to_message
 
 
 update : Session -> Msg -> Model -> ( Model, Cmd Msg, List Event )
@@ -145,6 +163,9 @@ update session msg model =
 
                         _ ->
                             ( model, Cmd.none, [] )
+
+        KeyPressIgnored ->
+            (model, Cmd.none, [])
 
         _ ->
             case ( msg, get_active_section model ) of

--- a/src/elm/Lia/View.elm
+++ b/src/elm/Lia/View.elm
@@ -3,7 +3,7 @@ module Lia.View exposing (view)
 import Flip exposing (flip)
 import Html exposing (Html)
 import Html.Attributes as Attr
-import Html.Events exposing (onClick)
+import Html.Events exposing (onClick, preventDefaultOn)
 import Lia.Index.View as Index
 import Lia.Markdown.Effect.Model exposing (current_paragraphs)
 import Lia.Markdown.Effect.View exposing (responsive, state)
@@ -13,7 +13,7 @@ import Lia.Model exposing (Model)
 import Lia.Settings.Model exposing (Mode(..))
 import Lia.Settings.Update exposing (toggle_sound)
 import Lia.Settings.View as Settings
-import Lia.Update exposing (Msg(..), get_active_section)
+import Lia.Update exposing (Msg(..), get_active_section, key_decoder)
 import Session exposing (Screen)
 import Translations as Trans exposing (Lang)
 
@@ -55,7 +55,7 @@ view_aside model =
 
 view_article : Screen -> Model -> Html Msg
 view_article screen model =
-    Html.article [ Attr.class "lia-slide" ] <|
+    Html.article [ Attr.class "lia-slide", preventDefaultOn "keydown" key_decoder ] <|
         case get_active_section model of
             Just section ->
                 [ section


### PR DESCRIPTION
This adds keypress events and interprets the left and right arrows for section navigation. Unfortunately that only works when a page element is focused, for example after clicking the "next section" icon.