### PR TITLE
Add LiaScript parsing to ASCII-art blocks

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "direct": {
             "andre-dietrich/elm-conditional": "1.0.0",
-            "andre-dietrich/elm-svgbob": "2.0.3",
+            "andre-dietrich/elm-svgbob": "4.0.1",
             "andre-dietrich/parser-combinators": "4.0.0",
             "dillonkearns/elm-oembed": "1.0.0",
             "elm/browser": "1.0.2",

--- a/elm.json
+++ b/elm.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "direct": {
             "andre-dietrich/elm-conditional": "1.0.0",
-            "andre-dietrich/elm-svgbob": "4.0.1",
+            "andre-dietrich/elm-svgbob": "4.0.3",
             "andre-dietrich/parser-combinators": "4.0.0",
             "dillonkearns/elm-oembed": "1.0.0",
             "elm/browser": "1.0.2",

--- a/src/elm/Lia/Markdown/Code/Parser.elm
+++ b/src/elm/Lia/Markdown/Code/Parser.elm
@@ -89,7 +89,7 @@ code_body char len =
     in
     manyTill
         (maybe indentation |> keep (regex ("(?:.(?!" ++ control_frame ++ "))*\\n")))
-        (indentation |> keep (regex control_frame))
+        (indentation |> keep (regex control_frame |> ignore spaces))
         |> map (String.concat >> String.dropRight 1)
 
 

--- a/src/elm/Lia/Markdown/Parser.elm
+++ b/src/elm/Lia/Markdown/Parser.elm
@@ -18,7 +18,9 @@ import Combine
         , onsuccess
         , optional
         , or
+        , putState
         , regex
+        , runParser
         , sepBy
         , sepBy1
         , skip
@@ -43,6 +45,7 @@ import Lia.Markdown.Table.Parser as Table
 import Lia.Markdown.Types exposing (Markdown(..), MarkdownS)
 import Lia.Parser.Context exposing (Context, indentation, indentation_append, indentation_pop, indentation_skip)
 import Lia.Parser.Helper exposing (c_frame, newline, newlines, spaces)
+import SvgBob
 
 
 run : Parser Context (List Markdown)
@@ -179,7 +182,60 @@ svgbob : Parser Context Markdown
 svgbob =
     md_annotations
         |> map ASCII
-        |> andMap (c_frame |> andThen svgbody)
+        |> andMap
+            (c_frame
+                |> andThen svgbody
+                |> andThen svgbobSub
+            )
+
+
+svgbobSub : String -> Parser Context (SvgBob.Configuration (List Markdown))
+svgbobSub str =
+    let
+        svg =
+            SvgBob.getElements
+                { fontSize = 14.0
+                , lineWidth = 1.0
+                , textWidth = 8.0
+                , textHeight = 16.0
+                , arcRadius = 4.0
+                , strokeColor = "black"
+                , textColor = "black"
+                , backgroundColor = "white"
+                , verbatim = '"'
+                , multilineVerbatim = True
+                , heightVerbatim = Just "100%"
+                , widthVerbatim = Nothing
+                }
+                str
+
+        fn context =
+            let
+                ( newContext, foreign ) =
+                    svg.foreign
+                        |> List.foldl
+                            (\( code, pos ) ( c, list ) ->
+                                case runParser run c (code ++ "\n") of
+                                    Ok ( state, _, md ) ->
+                                        ( state, ( md, pos ) :: list )
+
+                                    Err _ ->
+                                        ( c, list )
+                            )
+                            ( context, [] )
+            in
+            putState newContext
+                |> keep
+                    (succeed
+                        { svg = svg.svg
+                        , foreign = foreign
+                        , settings = svg.settings
+                        , columns = svg.columns
+                        , rows = svg.rows
+                        }
+                    )
+    in
+    withState fn
 
 
 subHeader : Parser Context ( Inlines, Int )

--- a/src/elm/Lia/Markdown/Types.elm
+++ b/src/elm/Lia/Markdown/Types.elm
@@ -9,6 +9,7 @@ import Lia.Markdown.Inline.Types exposing (Inlines)
 import Lia.Markdown.Quiz.Types exposing (Quiz)
 import Lia.Markdown.Survey.Types exposing (Survey)
 import Lia.Markdown.Table.Types exposing (Table)
+import SvgBob
 
 
 type Markdown
@@ -24,7 +25,7 @@ type Markdown
     | Survey Parameters Survey
     | Chart Parameters Chart
     | Code Code
-    | ASCII Parameters String
+    | ASCII Parameters (SvgBob.Configuration (List Markdown))
     | HTML Parameters (Node Markdown)
     | Header Parameters ( Inlines, Int )
     | Skip

--- a/src/elm/Lia/Markdown/View.elm
+++ b/src/elm/Lia/Markdown/View.elm
@@ -328,19 +328,33 @@ view_block config block =
         Chart attr chart ->
             Lazy.lazy3 Charts.view attr config.light chart
 
-        ASCII attr txt ->
-            Lazy.lazy3 view_ascii attr config.light txt
+        ASCII attr bob ->
+            view_ascii config attr bob
 
         Skip ->
             Html.text ""
 
 
-view_ascii : Parameters -> Bool -> String -> Html Msg
-view_ascii attr light =
-    SvgBob.init SvgBob.default
-        >> SvgBob.getSvg (toAttribute attr)
+view_ascii : Config Msg -> Parameters -> SvgBob.Configuration (List Markdown) -> Html Msg
+view_ascii config attr =
+    SvgBob.drawElements (toAttribute attr)
+        (\list ->
+            Html.div [] <|
+                case list of
+                    [ Paragraph [] content ] ->
+                        config.view content
+
+                    -- TODO: remove after styling
+                    (Code _) :: _ ->
+                        [ List.map (view_block config) list
+                            |> Html.div [ Attr.style "margin-top" "-16px" ]
+                        ]
+
+                    _ ->
+                        List.map (view_block config) list
+        )
         >> (\svg ->
-                if light then
+                if config.light then
                     svg
 
                 else


### PR DESCRIPTION
Verbatim code, that is surrounded by quotation marks `"`
is now treated as LiaScript content and thus parsed and
rendered accordingly.

  ``` ascii
  +-----------------------+
  | "$x = \frac{a}{12}$ " |
  +-----------+-----------+
              |
              V
  "* Markdown blocks can also be integrated, "
  "* if the starting quotation marks are in the same "
  "  column "

  "         {{1}}                                    "
  "This one is separated from the above and contains "
  "an effect ...                                     "
  "                                                  "
  "<script>alert('Hello World')</script> works too   "
  ```

[Issue: #31]