### PR TITLE
Fix(Styling): Unordered Lists

### DIFF
--- a/src/scss/03_elements/_elements.list.scss
+++ b/src/scss/03_elements/_elements.list.scss
@@ -31,7 +31,7 @@
     ul li ul li {
       padding-left: 1rem;
       &:before {
-        content: "\EA21";
+        content: "\EA22";
       }
     }
   }


### PR DESCRIPTION
The wrong icon was used for nested lists at level 3.

* 1

  - 2

    + 3 -- MapIcon was used, replaced by minus

[Closes: #53]