### PR TITLE
fix: Silent hidden TTS

### DIFF
--- a/src/elm/Lia/Markdown/Effect/Parser.elm
+++ b/src/elm/Lia/Markdown/Effect/Parser.elm
@@ -31,9 +31,8 @@ import Combine
 import Combine.Char exposing (anyChar)
 import Combine.Num exposing (int)
 import Dict
-import Lia.Markdown.Effect.Model exposing (Element)
+import Lia.Markdown.Effect.Model exposing (Content, Element)
 import Lia.Markdown.Effect.Types as Effect exposing (Effect)
-import Lia.Markdown.Inline.Stringify exposing (stringify)
 import Lia.Markdown.Inline.Types exposing (Inline(..), Inlines)
 import Lia.Markdown.Macro.Parser exposing (macro)
 import Lia.Markdown.Types exposing (Markdown(..))
@@ -241,29 +240,16 @@ add_comment visible ( idx, temp_narrator, par ) =
                             case Dict.get idx e.comments of
                                 Just cmt ->
                                     Dict.insert idx
-                                        (if visible then
-                                            { cmt
-                                                | comment = cmt.comment ++ "\n" ++ stringify par
-                                                , paragraphs = Array.push ( [], par ) cmt.paragraphs
-                                            }
-
-                                         else
-                                            { cmt | comment = cmt.comment ++ "\n" ++ stringify par }
-                                        )
+                                        { cmt
+                                            | content = Array.push (Content visible [] par) cmt.content
+                                        }
                                         e.comments
 
                                 _ ->
                                     Dict.insert idx
-                                        (Element
-                                            narrator
-                                            (stringify par)
-                                            (Array.fromList <|
-                                                if visible then
-                                                    [ ( [], par ) ]
-
-                                                else
-                                                    []
-                                            )
+                                        ([ Content visible [] par ]
+                                            |> Array.fromList
+                                            |> Element narrator
                                         )
                                         e.comments
                     }
@@ -284,7 +270,7 @@ get_counter idx =
             succeed <|
                 case Dict.get idx s.effect_model.comments of
                     Just e ->
-                        Array.length e.paragraphs - 1
+                        Array.length e.content - 1
 
                     Nothing ->
                         0

--- a/src/elm/Lia/Markdown/Effect/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Update.elm
@@ -99,7 +99,7 @@ update main sound msg model =
                 ( model
                 , Cmd.none
                 , case current_comment model of
-                    Just ( id, _, _ ) ->
+                    Just ( id, _ ) ->
                         if sound then
                             TTS.readFrom -1 id :: events
 
@@ -237,7 +237,7 @@ ttsReplay :
     -> Maybe Event
 ttsReplay sound model =
     case ( sound, current_comment model ) of
-        ( True, Just ( id, _, _ ) ) ->
+        ( True, Just ( id, _ ) ) ->
             Just <| TTS.readFrom -1 id
 
         _ ->

--- a/src/elm/Lia/View.elm
+++ b/src/elm/Lia/View.elm
@@ -230,10 +230,10 @@ slideA11y lang mode media effect id =
                     effect
                         |> Effect.current_paragraphs
                         |> List.map
-                            (\( active, counter, par ) ->
-                                par
+                            (\( active, counter, comment ) ->
+                                comment
                                     |> List.map
-                                        (Tuple.second
+                                        (.content
                                             >> List.map (view_inf effect.javascript lang (Just media))
                                             >> Html.p []
                                             >> Html.map (Tuple.pair id >> Script)


### PR DESCRIPTION
The original TTS had been refactored earlier, such that comments are now
are printed to the DOM but they are hidden. This way, Google and other
translators can be used to also translate the spoken comments. However,
this was not done for hidden-TTS, they were still kept in an obsolete
string. There had been a couple of changes:

* normal comments will get hidden ones attached to them, to preserve
  order
* lonely hidden comments will be attached to the end of every document,
  this way the current TTS handling can find them and speak ...

[Closes: #54]