### PR TITLE
feat: Add support for additional protocols

### DIFF
--- a/src/elm/Lia/Markdown/HTML/Attributes.elm
+++ b/src/elm/Lia/Markdown/HTML/Attributes.elm
@@ -221,22 +221,47 @@ basis is automatically added:
 -}
 toURL : String -> String -> String
 toURL basis url =
-    if
-        url
-            |> String.toLower
-            |> allowed
-    then
+    if allowedProtocol url then
         url
 
     else
         basis ++ url
 
 
-allowed : String -> Bool
-allowed url =
-    String.startsWith "https://" url
-        || String.startsWith "http://" url
-        || String.startsWith "hyper://" url
+{-| List of allowed supported protocols.
+-}
+allowedProtocol : String -> Bool
+allowedProtocol url =
+    case
+        url
+            |> String.split "://"
+            |> List.head
+            |> Maybe.withDefault ""
+            |> String.toLower
+    of
+        "https" ->
+            True
+
+        "http" ->
+            True
+
+        "file" ->
+            True
+
+        "hyper" ->
+            True
+
+        "dat" ->
+            True
+
+        "ipfs" ->
+            True
+
+        "ipns" ->
+            True
+
+        _ ->
+            False
 
 
 {-| General HTML attribute parser, the base-URL is added in front of relative

--- a/src/typescript/helper.ts
+++ b/src/typescript/helper.ts
@@ -1,0 +1,11 @@
+export function allowedProtocol(url: string) {
+  return (
+    url.startsWith('https://') ||
+    url.startsWith('http://') ||
+    url.startsWith('file://') ||
+    url.startsWith('hyper://') ||
+    url.startsWith('dat://') ||
+    url.startsWith('ipfs://') ||
+    url.startsWith('ipns://')
+  )
+}

--- a/src/typescript/webcomponents/chart.ts
+++ b/src/typescript/webcomponents/chart.ts
@@ -9,6 +9,7 @@ import 'echarts/i18n/langFR.js'
 import 'echarts/i18n/langJA.js'
 import 'echarts/i18n/langTH.js'
 import 'echarts/i18n/langZH.js'
+import { allowedProtocol } from '../helper'
 
 const style = 'width: 100%; height: 400px; margin-top: -0.2em;'
 
@@ -144,11 +145,7 @@ customElements.define(
           this.geoJson.url = newValue
           this.geoJson.data = null
 
-          if (
-            this.geoJson.url.startsWith('https://') ||
-            this.geoJson.url.startsWith('http://') ||
-            this.geoJson.url.startsWith('hyper://')
-          ) {
+          if (allowedProtocol(this.geoJson.url)) {
             let xmlHttp = new XMLHttpRequest()
             let self = this
             xmlHttp.onreadystatechange = function () {

--- a/src/typescript/webcomponents/preview-lia.ts
+++ b/src/typescript/webcomponents/preview-lia.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import { Elm } from '../../elm/Worker.elm'
+import { allowedProtocol } from '../helper'
 
 function fetch(self: PreviewLia) {
   let http = new XMLHttpRequest()
@@ -263,11 +264,7 @@ class PreviewLia extends HTMLElement {
   }
 
   addBase(url: string) {
-    if (
-      url.startsWith('https://') ||
-      url.startsWith('http://') ||
-      url.startsWith('hyper://')
-    ) {
+    if (allowedProtocol(url)) {
       return url
     }
 


### PR DESCRIPTION
This adds the additional support for further protocols, next to base
HTTP and HTTPS...

Allowed protocols are now:

- `file://`
- `ipfs://`
- `ipns://`
- `hyper://`
- `dat://`
- `ftp://`

[Issue: #58]