### PR TITLE
Feat/main settings

### DIFF
--- a/src/elm/Const.elm
+++ b/src/elm/Const.elm
@@ -2,7 +2,9 @@ module Const exposing
     ( align
     , globalBreakpoints
     , icon
-    , proxy
+    , urlLiascript
+    , urlLiascriptCourse
+    , urlProxy
     )
 
 
@@ -51,6 +53,16 @@ file, but not with the URL:
 [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 
 -}
-proxy : String
-proxy =
+urlProxy : String
+urlProxy =
     "https://cors-anywhere.herokuapp.com/"
+
+
+urlLiascript : String
+urlLiascript =
+    "https://LiaScript.github.io"
+
+
+urlLiascriptCourse : String
+urlLiascriptCourse =
+    urlLiascript ++ "/course/?"

--- a/src/elm/Error/Message.elm
+++ b/src/elm/Error/Message.elm
@@ -58,11 +58,11 @@ loadingError : String -> String -> Http.Error -> String
 loadingError message url networkStatus =
     let
         hasProxy =
-            String.startsWith Const.proxy url
+            String.startsWith Const.urlProxy url
 
         rootUrl =
             if hasProxy then
-                String.replace Const.proxy "" url
+                String.replace Const.urlProxy "" url
 
             else
                 url
@@ -96,7 +96,7 @@ whatIsLiaScript =
     """LiaScript is a domain specific language for educational content that is based on Markdown.
 For more information visit some of the following sources:
 
-* Project-website: https://LiaScript.github.io
+* Project-website: """ ++ Const.urlLiascript ++ """
 * Documentation: https://github.com/liascript/docs
 * YouTube: https://www.youtube.com/channel/UCyiTe2GkW_u05HSdvUblGYg
 """
@@ -128,8 +128,8 @@ comment:  Try to write a short comment about
 
 This is your **course** initialization stub.
 
-Please see the [Docs](https://liascript.github.io/course/?https://raw.githubusercontent.com/liaScript/docs/master/README.md)
-to find out what is possible in [LiaScript](https://liascript.github.io).
+Please see the [Docs](""" ++ Const.urlLiascriptCourse ++ """https://raw.githubusercontent.com/liaScript/docs/master/README.md)
+to find out what is possible in [LiaScript](""" ++ Const.urlLiascript ++ """).
 
 If you want to use instant help in your Atom IDE, please type **lia** to see all available shortcuts.
 
@@ -264,7 +264,7 @@ else {
 
 Find out what you also can do ...
 
-https://liascript.github.io/course/?https://raw.githubusercontent.com/liaScript/docs/master/README.md
+""" ++ Const.urlLiascriptCourse ++ """https://raw.githubusercontent.com/liaScript/docs/master/README.md
 ````
 """
 

--- a/src/elm/Index/View.elm
+++ b/src/elm/Index/View.elm
@@ -14,57 +14,65 @@ import Lia.Markdown.Inline.Stringify exposing (stringify)
 import Lia.Markdown.Inline.Types exposing (Inlines)
 import Lia.Markdown.Inline.View as Inline
 import Lia.Parser.PatReplace exposing (link)
+import Lia.Settings.Types exposing (Settings)
+import Lia.Settings.View as Settings
 import Lia.Utils exposing (blockKeydown, btn, btnIcon)
 import Session exposing (Session)
 import Translations exposing (Lang(..))
 
 
-view : Session -> Model -> Html Msg
-view session model =
+view : Session -> Settings -> Model -> Html Msg
+view session settings model =
     Html.div [ Attr.class "p-2" ]
-        [ Html.h1 [] [ Html.text "Lia: Open-courSes" ]
-        , searchBar model.input
-        , if List.isEmpty model.courses && model.initialized then
-            Html.section [] <|
-                [ Html.br [] []
-                , Html.p
-                    [ Attr.class "lia-paragraph" ]
-                    [ Html.text "If you cannot see any courses in this list, try out one of the following links, to get more information about this project and to visit some examples and free interactive books."
+        [ [ ( Settings.menuSettings, "settings" )
+          ]
+            |> Settings.header En session.screen settings Const.icon
+            |> Html.map UpdateSettings
+        , Html.main_ [ Attr.class "lia-slide__content" ]
+            [ Html.h1 [] [ Html.text "Lia: Open-courSes" ]
+            , searchBar model.input
+            , if List.isEmpty model.courses && model.initialized then
+                Html.section [] <|
+                    [ Html.br [] []
+                    , Html.p
+                        [ Attr.class "lia-paragraph" ]
+                        [ Html.text "If you cannot see any courses in this list, try out one of the following links, to get more information about this project and to visit some examples and free interactive books."
+                        ]
+                    , Html.u
+                        []
+                        [ Html.li []
+                            [ Html.a
+                                [ Attr.href "https://LiaScript.github.io" ]
+                                [ Html.text "Project-Website" ]
+                            ]
+                        , Html.li []
+                            [ Html.a
+                                [ href "https://raw.githubusercontent.com/liaScript/docs/master/README.md" ]
+                                [ Html.text "Project-Documentation" ]
+                            ]
+                        , Html.li []
+                            [ Html.a
+                                [ href "https://raw.githubusercontent.com/liaScript/index/master/README.md" ]
+                                [ Html.text "Index" ]
+                            ]
+                        ]
+                    , Html.br [] []
+                    , Html.p
+                        [ Attr.class "lia-paragraph" ]
+                        [ Html.text "At the end, we hope to learn from your courses." ]
+                    , Html.p
+                        [ Attr.class "lia-paragraph" ]
+                        [ Html.text "Have a nice one ;-) ..." ]
                     ]
-                , Html.u
-                    []
-                    [ Html.li []
-                        [ Html.a
-                            [ Attr.href "https://LiaScript.github.io" ]
-                            [ Html.text "Project-Website" ]
-                        ]
-                    , Html.li []
-                        [ Html.a
-                            [ href "https://raw.githubusercontent.com/liaScript/docs/master/README.md" ]
-                            [ Html.text "Project-Documentation" ]
-                        ]
-                    , Html.li []
-                        [ Html.a
-                            [ href "https://raw.githubusercontent.com/liaScript/index/master/README.md" ]
-                            [ Html.text "Index" ]
-                        ]
-                    ]
-                , Html.br [] []
-                , Html.p
-                    [ Attr.class "lia-paragraph" ]
-                    [ Html.text "At the end, we hope to learn from your courses." ]
-                , Html.p
-                    [ Attr.class "lia-paragraph" ]
-                    [ Html.text "Have a nice one ;-) ..." ]
-                ]
 
-          else if model.initialized then
-            model.courses
-                |> List.map (card session.share)
-                |> Html.div [ Attr.class "preview-grid" ]
+              else if model.initialized then
+                model.courses
+                    |> List.map (card session.share)
+                    |> Html.div [ Attr.class "preview-grid" ]
 
-          else
-            Html.text ""
+              else
+                Html.text ""
+            ]
         ]
 
 

--- a/src/elm/Index/View.elm
+++ b/src/elm/Index/View.elm
@@ -260,7 +260,7 @@ viewControls hasShareAPI title comment course =
             , tabbable = True
             , icon = "icon-refresh"
             }
-            [ Attr.class "lia-btn--tag lia-btn--transparent text-grey border-grey px-1" ]
+            [ Attr.class "lia-btn--tag lia-btn--transparent text-yellow-dark border-yellow-dark px-1" ]
         , if hasShareAPI then
             btnIcon
                 { msg =
@@ -281,10 +281,10 @@ viewControls hasShareAPI title comment course =
             Nothing ->
                 Html.a
                     [ href course.id
-                    , Attr.class "lia-btn lia-btn--transparent lia-btn--tag icon icon-login px-1 text-turquoise border-turquoise"
+                    , Attr.class "lia-btn lia-btn--transparent lia-btn--tag px-1 border-turquoise"
                     , Attr.title "open"
                     ]
-                    []
+                    [ Html.i [ Attr.class "icon icon-login text-turquoise" ] [] ]
 
             Just _ ->
                 btnIcon

--- a/src/elm/Index/View.elm
+++ b/src/elm/Index/View.elm
@@ -42,7 +42,7 @@ view session settings model =
                         []
                         [ Html.li []
                             [ Html.a
-                                [ Attr.href "https://LiaScript.github.io" ]
+                                [ Attr.href Const.urlLiascript ]
                                 [ Html.text "Project-Website" ]
                             ]
                         , Html.li []
@@ -268,7 +268,7 @@ viewControls hasShareAPI title comment course =
                         Share
                             (title |> stringify)
                             ((comment |> stringify) ++ "\n")
-                            ("https://LiaScript.github.io/course/?" ++ course.id)
+                            (Const.urlLiascriptCourse ++ course.id)
                 , title = "share"
                 , tabbable = True
                 , icon = "icon-social"

--- a/src/elm/Index/View.elm
+++ b/src/elm/Index/View.elm
@@ -260,7 +260,7 @@ viewControls hasShareAPI title comment course =
             , tabbable = True
             , icon = "icon-refresh"
             }
-            [ Attr.class "lia-btn--tag lia-btn--transparent text-grey-dark border-grey px-1" ]
+            [ Attr.class "lia-btn--tag lia-btn--transparent text-grey border-grey px-1" ]
         , if hasShareAPI then
             btnIcon
                 { msg =

--- a/src/elm/Lia/Settings/View.elm
+++ b/src/elm/Lia/Settings/View.elm
@@ -2,6 +2,7 @@ module Lia.Settings.View exposing
     ( btnIndex
     , btnSupport
     , design
+    , header
     , menuInformation
     , menuMode
     , menuSettings
@@ -15,6 +16,7 @@ import Accessibility.Role as A11y_Role
 import Accessibility.Widget as A11y_Widget
 import Array
 import Conditional.List as CList
+import Const
 import Dict exposing (Dict)
 import Html exposing (Html)
 import Html.Attributes as Attr
@@ -26,6 +28,7 @@ import Lia.Settings.Types exposing (Action(..), Mode(..), Settings)
 import Lia.Settings.Update exposing (Msg(..), Toggle(..))
 import Lia.Utils exposing (blockKeydown, btn, btnIcon, noTranslate)
 import QRCode
+import Session exposing (Screen)
 import Translations as Trans exposing (Lang)
 
 
@@ -607,3 +610,64 @@ action msg open =
 doAction : Action -> Msg
 doAction =
     Action >> Toggle
+
+
+header :
+    Lang
+    -> Screen
+    -> Settings
+    -> String
+    -> List ( Lang -> Bool -> Settings -> List (Html Msg), String )
+    -> Html Msg
+header lang screen settings logo buttons =
+    let
+        tabbable =
+            screen.width >= Const.globalBreakpoints.md || settings.support_menu
+    in
+    [ Html.div [ Attr.class "lia-header__left" ] []
+    , Html.div [ Attr.class "lia-header__middle" ]
+        [ Html.img
+            [ Attr.src logo
+            , Attr.class "lia_header__logo"
+            , Attr.alt "logo"
+            ]
+            []
+        ]
+    , Html.div [ Attr.class "lia-header__right" ]
+        [ Html.div
+            [ Attr.class "lia-support-menu"
+            , Attr.id "lia-support-menu"
+            , Attr.class <|
+                if settings.support_menu then
+                    "lia-support-menu--open"
+
+                else
+                    "lia-support-menu--closed"
+            ]
+            [ btnSupport lang settings.support_menu
+            , Html.div
+                [ Attr.class "lia-support-menu__collapse"
+                ]
+                [ buttons
+                    |> List.map
+                        (\( fn, class ) ->
+                            Html.li
+                                [ Attr.class <| "nav__item lia-support-menu__item lia-support-menu__item--" ++ class
+                                , A11y_Role.menuItem
+                                , A11y_Widget.hasMenuPopUp
+                                ]
+                                (fn lang tabbable settings)
+                        )
+                    |> Html.ul
+                        [ Attr.class "nav lia-support-menu__nav"
+                        , A11y_Role.menuBar
+                        , A11y_Key.tabbable False
+                        ]
+                ]
+            ]
+        ]
+    ]
+        |> Html.header
+            [ Attr.class "lia-header"
+            , Attr.id "lia-toolbar-nav"
+            ]

--- a/src/elm/Lia/View.elm
+++ b/src/elm/Lia/View.elm
@@ -333,64 +333,13 @@ navButton title id class msg =
 -}
 slideTopBar : Lang -> Screen -> String -> Settings -> Definition -> Html Msg
 slideTopBar lang screen url settings def =
-    let
-        tabbable =
-            screen.width >= Const.globalBreakpoints.md || settings.support_menu
-    in
-    [ Html.div [ Attr.class "lia-header__left" ] []
-    , Html.div [ Attr.class "lia-header__middle" ]
-        [ Html.img
-            [ def
-                |> Definition.getIcon
-                |> Attr.src
-            , Attr.class "lia_header__logo"
-            , Attr.alt "LiaScript"
-            ]
-            []
-        ]
-    , Html.div [ Attr.class "lia-header__right" ]
-        [ Html.div
-            [ Attr.class "lia-support-menu"
-            , Attr.id "lia-support-menu"
-            , Attr.class <|
-                if settings.support_menu then
-                    "lia-support-menu--open"
-
-                else
-                    "lia-support-menu--closed"
-            ]
-            [ Settings.btnSupport lang settings.support_menu
-            , Html.div
-                [ Attr.class "lia-support-menu__collapse"
-                ]
-                [ [ ( Settings.menuMode, "mode" )
-                  , ( Settings.menuSettings, "settings" )
-                  , ( Settings.menuTranslations def, "lang" )
-                  , ( Settings.menuShare url, "share" )
-                  , ( Settings.menuInformation def, "info" )
-                  ]
-                    |> List.map
-                        (\( fn, class ) ->
-                            Html.li
-                                [ Attr.class <| "nav__item lia-support-menu__item lia-support-menu__item--" ++ class
-                                , A11y_Role.menuItem
-                                , A11y_Widget.hasMenuPopUp
-                                ]
-                                (fn lang tabbable settings)
-                        )
-                    |> Html.ul
-                        [ Attr.class "nav lia-support-menu__nav"
-                        , A11y_Role.menuBar
-                        , A11y_Key.tabbable False
-                        ]
-                ]
-            ]
-        ]
+    [ ( Settings.menuMode, "mode" )
+    , ( Settings.menuSettings, "settings" )
+    , ( Settings.menuTranslations def, "lang" )
+    , ( Settings.menuShare url, "share" )
+    , ( Settings.menuInformation def, "info" )
     ]
-        |> Html.header
-            [ Attr.class "lia-header"
-            , Attr.id "lia-toolbar-nav"
-            ]
+        |> Settings.header lang screen settings (Definition.getIcon def)
         |> Html.map UpdateSettings
 
 

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -270,7 +270,7 @@ update msg model =
             load_readme readme model
 
         Load_ReadMe_Result url (Err info) ->
-            if String.startsWith Const.proxy url then
+            if String.startsWith Const.urlProxy url then
                 startWithError
                     { model
                         | state =
@@ -290,7 +290,7 @@ update msg model =
 
             else
                 ( model
-                , Session.setQuery (Const.proxy ++ url) model.session
+                , Session.setQuery (Const.urlProxy ++ url) model.session
                     |> .url
                     |> Session.load
                 )
@@ -312,7 +312,7 @@ update msg model =
                 }
 
         Load_Template_Result url (Err info) ->
-            if String.startsWith Const.proxy url then
+            if String.startsWith Const.urlProxy url then
                 startWithError
                     { model
                         | state =
@@ -321,7 +321,7 @@ update msg model =
                     }
 
             else
-                ( model, download Load_Template_Result (Const.proxy ++ url) )
+                ( model, download Load_Template_Result (Const.urlProxy ++ url) )
 
 
 {-| **@private:** Parsing has been finished, initialize lia, update the url and

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -25,7 +25,7 @@ import Lia.Script
 import Model exposing (Model, State(..))
 import Port.Event exposing (Event)
 import Process
-import Session exposing (Screen)
+import Session exposing (Screen, Session)
 import Task
 import Translations
 import Url
@@ -197,10 +197,13 @@ update msg model =
 
         UpdateIndex childMsg ->
             let
-                ( index, cmd, events ) =
-                    Index.update childMsg model.index
+                ( settings, ( index, cmd, events ) ) =
+                    Index.update childMsg model.lia.settings model.index
+
+                lia =
+                    model.lia
             in
-            ( { model | index = index }
+            ( { model | index = index, lia = { lia | settings = settings } }
             , batch UpdateIndex cmd events
             )
 

--- a/src/elm/View.elm
+++ b/src/elm/View.elm
@@ -30,7 +30,7 @@ view model =
                 ]
 
             Idle ->
-                [ Html.map UpdateIndex <| Index.view model.session model.index
+                [ Html.map UpdateIndex <| Index.view model.session model.lia.settings model.index
                 ]
 
             Loading ->

--- a/src/scss/05_components/_components.card.scss
+++ b/src/scss/05_components/_components.card.scss
@@ -1,10 +1,10 @@
 .lia-card {
-  background-color: white;
-  border: 1px solid #399193;
+  background-color: rgb(var(--color-background));
+  border: 1px solid rgb(var(--color-highlight));
   display: flex;
   flex-direction: column;
   position: relative;
-  color: black;
+  color: rgb(var(--color-text));
 
   @include breakpoint-only('sm', 'md') {
     display: grid;
@@ -69,13 +69,12 @@
   }
 
   &__title {
-    color: rgb(var(--lia-anthracite));
     display: inline-block;
     margin: 0 0 2rem;
     position: relative;
 
     &:before {
-      background-color: rgb(var(--lia-turquoise));
+      background-color: rgb(var(--color-highlight));
       bottom: -0.5rem;
       content: '';
       height: 1px;


### PR DESCRIPTION
This change externalizes header settings, so that it can now also be used to change the appearance of the index page. Additionally the cards do now also follow the color conventions and additionally the control-buttons have been updated to red -> delete, yellow -> reset a course, turquoise -> open ...

This can be later used to add more settings into the main header in order to support more features for synchronization or for graph representations...