### PR TITLE
fix(Parser): References with escape characters

### DIFF
--- a/src/elm/Lia/Markdown/Inline/Parser.elm
+++ b/src/elm/Lia/Markdown/Inline/Parser.elm
@@ -417,7 +417,7 @@ strings =
 
 stringBase : Parser s (Parameters -> Inline)
 stringBase =
-    regex "[^@*+_~:;`\\^\\[\\]\\(\\)|{}\\\\\\n<>=$ \"\\-]+"
+    regex "[^\\[\\]\\(\\)@*+_~:;`\\^|{}\\\\\\n<>=$ \"\\-]+"
         |> map Chars
 
 
@@ -460,7 +460,7 @@ stringSuperscript =
 
 stringCharacters : Parser s (Parameters -> Inline)
 stringCharacters =
-    regex "[~:_;=${}\\[\\]\\(\\)\\-+\"]"
+    regex "[\\[\\]\\(\\)~:_;=${}\\-+\"*]"
         |> map Chars
 
 


### PR DESCRIPTION
The order of "operators" brackets and parathesis is now more important
than asterisk or underscore...

Fixes: #48