### PR TITLE
feat(Code): Add resizable terminal windows

### DIFF
--- a/src/elm/Lia/Markdown/Code/Json.elm
+++ b/src/elm/Lia/Markdown/Code/Json.elm
@@ -67,7 +67,7 @@ project :
     -> Repo
     -> (List Parameters -> Project)
 project files version active log repository =
-    Project files -1 version active repository "" log False Nothing
+    Project files -1 version active repository "" log Nothing False Nothing
 
 
 toProject : JD.Decoder (List Parameters -> Project)

--- a/src/elm/Lia/Markdown/Code/Types.elm
+++ b/src/elm/Lia/Markdown/Code/Types.elm
@@ -52,6 +52,7 @@ type alias Project =
     , repository : Repo
     , evaluation : String
     , log : Log
+    , logSize : Maybe String
     , running : Bool
     , terminal : Maybe Terminal
     , attr : List Parameters
@@ -121,6 +122,7 @@ initProject fullscreen array comment output =
     , evaluation = comment
     , version_active = 0
     , log = output
+    , logSize = Nothing
     , running = False
     , terminal = Nothing
     , repository = Dict.fromList repository

--- a/src/elm/Lia/Markdown/Code/Update.elm
+++ b/src/elm/Lia/Markdown/Code/Update.elm
@@ -29,6 +29,7 @@ type Msg
     | Last Int
     | UpdateTerminal Int Terminal.Msg
     | Handle Event
+    | Resize Code String
 
 
 handle : Event -> Msg
@@ -242,10 +243,30 @@ update scripts msg model =
                 |> Maybe.map (\p -> ( p, Event.stop idx ))
                 |> maybe_update idx model
 
+        Resize code height ->
+            ( case code of
+                Evaluate id ->
+                    { model | evaluate = onResize id height model.evaluate }
+
+                Highlight id ->
+                    { model | highlight = onResize id height model.highlight }
+            , []
+            )
+
         UpdateTerminal idx childMsg ->
             model
                 |> maybe_project idx (update_terminal (Event.input idx) childMsg)
                 |> maybe_update idx model
+
+
+onResize : Int -> String -> Array Project -> Array Project
+onResize id height code =
+    CArray.setWhen id
+        (code
+            |> Array.get id
+            |> Maybe.map (\pro -> { pro | logSize = Just height })
+        )
+        code
 
 
 update_terminal : (String -> Event) -> Terminal.Msg -> Project -> ( Project, List Event )

--- a/src/entry/app/index.html
+++ b/src/entry/app/index.html
@@ -17,6 +17,7 @@
   <script defer src="../../typescript/webcomponents/preview-lia.ts"></script>
   <script defer src="../../typescript/webcomponents/preview-link.ts"></script>
   <script defer src="../../typescript/webcomponents/format.ts"></script>
+  <script defer src="../../typescript/webcomponents/terminal.ts"></script>
   <script>
     if (process.env.NODE_ENV !== 'development') {
       if ('serviceWorker' in navigator) {

--- a/src/entry/base/index.html
+++ b/src/entry/base/index.html
@@ -16,6 +16,7 @@
   <script defer src="../../typescript/webcomponents/preview-lia.ts"></script>
   <script defer src="../../typescript/webcomponents/preview-link.ts"></script>
   <script defer src="../../typescript/webcomponents/format.ts"></script>
+  <script defer src="../../typescript/webcomponents/terminal.ts"></script>
   <!--script defer src="https://code.responsivevoice.org/responsivevoice.js"></script-->
 
   <link rel="shortcut icon" sizes="192x192" href="../../assets/logo_192.png">

--- a/src/entry/dev/index.html
+++ b/src/entry/dev/index.html
@@ -16,6 +16,7 @@
   <script defer src="../../typescript/webcomponents/preview-lia.ts"></script>
   <script defer src="../../typescript/webcomponents/preview-link.ts"></script>
   <script defer src="../../typescript/webcomponents/format.ts"></script>
+  <script defer src="../../typescript/webcomponents/terminal.ts"></script>
   <script>
     if (process.env.NODE_ENV !== 'development') {
       if ('serviceWorker' in navigator) {

--- a/src/entry/scorm1.2/index.html
+++ b/src/entry/scorm1.2/index.html
@@ -16,6 +16,7 @@
   <script defer src="../../typescript/webcomponents/preview-lia.ts"></script>
   <script defer src="../../typescript/webcomponents/preview-link.ts"></script>
   <script defer src="../../typescript/webcomponents/format.ts"></script>
+  <script defer src="../../typescript/webcomponents/terminal.ts"></script>
   <script defer src="https://code.responsivevoice.org/responsivevoice.js"></script>
 
   <link rel="shortcut icon" sizes="192x192" href="../../assets/logo_192.png">

--- a/src/scss/03_elements/_elements.code.scss
+++ b/src/scss/03_elements/_elements.code.scss
@@ -64,6 +64,7 @@
       background-color: rgb(var(--lia-anthracite));
       margin: 0;
       max-height: 20rem;
+      resize: vertical;
       overflow-y: auto;
       padding: 1rem 1.6rem;
     }

--- a/src/typescript/webcomponents/terminal.ts
+++ b/src/typescript/webcomponents/terminal.ts
@@ -1,0 +1,46 @@
+customElements.define(
+  'lia-terminal',
+  class extends HTMLElement {
+    private resizeObserver: ResizeObserver
+    private height_?: string
+
+    constructor() {
+      super()
+
+      let self = this
+      this.resizeObserver = new ResizeObserver(function (e) {
+        if (self.style.height) {
+          self.height_ = self.style.height
+          self.update()
+          self.dispatchEvent(new CustomEvent('onchangeheight'))
+        }
+      })
+    }
+
+    connectedCallback() {
+      this.resizeObserver.observe(this)
+    }
+
+    disconnectedCallback() {
+      this.resizeObserver.disconnect()
+    }
+
+    update() {
+      if (this.height_) {
+        this.style.maxHeight = 'none'
+        this.style.height = this.height_
+      }
+    }
+
+    get height() {
+      return this.height_
+    }
+
+    set height(val) {
+      if (this.height_ != val) {
+        this.height_ = val
+        this.update()
+      }
+    }
+  }
+)


### PR DESCRIPTION
The max-height is still set to 200px and the terminal will grow up to
this size. The user can now also resize the terminal manually, in this
case the max-height property will be overwritten and temporally the user
defined size will be stored until the next reload.

[Issue: #69]