### PR TITLE
Fix/links

### DIFF
--- a/src/elm/Lia/Markdown/HTML/Attributes.elm
+++ b/src/elm/Lia/Markdown/HTML/Attributes.elm
@@ -221,7 +221,7 @@ basis is automatically added:
 -}
 toURL : String -> String -> String
 toURL basis url =
-    if allowedProtocol url then
+    if allowedProtocol url || String.startsWith "#" url then
         url
 
     else

--- a/src/elm/Lia/Markdown/Inline/View.elm
+++ b/src/elm/Lia/Markdown/Inline/View.elm
@@ -303,8 +303,12 @@ img config attr alt_ url_ title_ width =
     Html.img
         (Attr.src url_
             :: Attr.attribute "loading" "lazy"
-            :: Attr.attribute "onClick" ("window.img_Click(\"" ++ url_ ++ "\")")
-            :: toAttribute attr
+            :: (if List.isEmpty attr then
+                    [ Attr.attribute "onClick" ("window.img_Click(\"" ++ url_ ++ "\")") ]
+
+                else
+                    toAttribute attr
+               )
             |> CList.addIf (width == Nothing) (load url_)
             |> CList.addWhen (title config title_)
             |> CList.addWhen (alt config alt_)


### PR DESCRIPTION
This solves some link issues:

* a base is now set to all relative links, so that pdfs and other resources can be referenced this way
* url-parameter of multimedia links are now preserved in order to support mute, autoplay, start, stop, etc.
* fix `#Fragment` links, local sections can also be referenced from HTML elements via `href="#fragment"`
* custom styled images do not trigger an modal view anymore ...