### PR TITLE
Feat/return

### DIFF
--- a/src/elm/Index/Update.elm
+++ b/src/elm/Index/Update.elm
@@ -198,7 +198,7 @@ updateSettings msg settings ( model, cmd, events ) =
             in
             ( return.value
             , ( model
-              , Cmd.batch [ cmd, Cmd.map UpdateSettings return.cmd ]
+              , Cmd.batch [ cmd, Cmd.map UpdateSettings return.command ]
               , List.append events return.events
               )
             )

--- a/src/elm/Index/Update.elm
+++ b/src/elm/Index/Update.elm
@@ -193,13 +193,13 @@ updateSettings msg settings ( model, cmd, events ) =
     case msg of
         UpdateSettings subMsg ->
             let
-                ( newSettings, newCmd, newEvents ) =
+                return =
                     Settings.update Nothing subMsg settings
             in
-            ( newSettings
+            ( return.value
             , ( model
-              , Cmd.batch [ cmd, Cmd.map UpdateSettings newCmd ]
-              , List.append events newEvents
+              , Cmd.batch [ cmd, Cmd.map UpdateSettings return.cmd ]
+              , List.append events return.events
               )
             )
 

--- a/src/elm/Index/Update.elm
+++ b/src/elm/Index/Update.elm
@@ -266,8 +266,8 @@ decRelease =
         Definition.decode
 
 
-{-| Check if the current passed version string is allso available as accessible
-from the local cache. Major verions of `0` are not stored permanently.
+{-| Check if the current passed version string is also available as accessible
+from the local cache. Major versions of `0` are not stored permanently.
 -}
 inCache : String -> Course -> Bool
 inCache version course =

--- a/src/elm/Lia/Index/View.elm
+++ b/src/elm/Lia/Index/View.elm
@@ -15,7 +15,7 @@ import Html.Attributes as Attr
 import Html.Events exposing (onClick, onInput)
 import Lia.Index.Model exposing (Model)
 import Lia.Index.Update exposing (Msg(..))
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script
 import Lia.Markdown.Inline.View exposing (view_inf)
 import Lia.Section exposing (Section, Sections)
 import Lia.Utils exposing (blockKeydown, btn, icon)

--- a/src/elm/Lia/Markdown/Code/Update.elm
+++ b/src/elm/Lia/Markdown/Code/Update.elm
@@ -38,7 +38,7 @@ handle =
     Handle
 
 
-restore : JE.Value -> Model -> Return Model Never sub
+restore : JE.Value -> Model -> Return Model msg sub
 restore json model =
     case
         model.evaluate
@@ -66,7 +66,7 @@ restore json model =
                 |> Return.value
 
 
-update : Scripts sub -> Msg -> Model -> Return Model Never sub
+update : Scripts a -> Msg -> Model -> Return Model msg sub
 update scripts msg model =
     case msg of
         Eval idx ->
@@ -300,7 +300,7 @@ maybe_project idx f =
         >> Maybe.map f
 
 
-maybe_update : Int -> Model -> Maybe ( Project, List Event ) -> Return Model Never sub
+maybe_update : Int -> Model -> Maybe ( Project, List Event ) -> Return Model msg sub
 maybe_update idx model project =
     case project of
         Just ( p, logs ) ->
@@ -312,7 +312,7 @@ maybe_update idx model project =
             Return.value model
 
 
-update_file : Int -> Int -> Model -> (File -> File) -> (File -> List Event) -> Return Model Never sub
+update_file : Int -> Int -> Model -> (File -> File) -> (File -> List Event) -> Return Model msg sub
 update_file id_1 id_2 model f f_log =
     case Array.get id_1 model.evaluate of
         Just project ->

--- a/src/elm/Lia/Markdown/Code/Update.elm
+++ b/src/elm/Lia/Markdown/Code/Update.elm
@@ -16,6 +16,7 @@ import Lia.Markdown.Code.Types exposing (Code(..), File, Model, Project, loadVer
 import Lia.Markdown.Effect.Script.Types exposing (Scripts)
 import Port.Eval exposing (Eval)
 import Port.Event exposing (Event)
+import Return exposing (Return)
 
 
 type Msg
@@ -37,7 +38,7 @@ handle =
     Handle
 
 
-restore : JE.Value -> Model -> ( Model, List Event )
+restore : JE.Value -> Model -> Return Model Never sub
 restore json model =
     case
         model.evaluate
@@ -46,22 +47,26 @@ restore json model =
             |> Json.toVector json
     of
         Ok (Just vector) ->
-            ( Json.merge model vector, [] )
+            Json.merge model vector
+                |> Return.value
 
         Ok Nothing ->
-            ( model
-            , if Array.length model.evaluate == 0 then
-                []
+            model
+                |> Return.value
+                |> Return.events
+                    (if Array.length model.evaluate == 0 then
+                        []
 
-              else
-                [ Event.store model.evaluate ]
-            )
+                     else
+                        [ Event.store model.evaluate ]
+                    )
 
         Err _ ->
-            ( model, [] )
+            model
+                |> Return.value
 
 
-update : Scripts a -> Msg -> Model -> ( Model, List Event )
+update : Scripts sub -> Msg -> Model -> Return Model Never sub
 update scripts msg model =
     case msg of
         Eval idx ->
@@ -87,7 +92,7 @@ update scripts msg model =
                 (Event.flip_view id_1 id_2)
 
         FlipView (Highlight id_1) id_2 ->
-            ( { model
+            { model
                 | highlight =
                     CArray.setWhen id_1
                         (model.highlight
@@ -101,12 +106,11 @@ update scripts msg model =
                                 )
                         )
                         model.highlight
-              }
-            , []
-            )
+            }
+                |> Return.value
 
         FlipFullscreen (Highlight id_1) id_2 ->
-            ( { model
+            { model
                 | highlight =
                     CArray.setWhen id_1
                         (model.highlight
@@ -120,9 +124,8 @@ update scripts msg model =
                                 )
                         )
                         model.highlight
-              }
-            , []
-            )
+            }
+                |> Return.value
 
         FlipFullscreen (Evaluate id_1) id_2 ->
             update_file
@@ -235,7 +238,7 @@ update scripts msg model =
                         |> maybe_update event.section model
 
                 _ ->
-                    ( model, [] )
+                    Return.value model
 
         Stop idx ->
             model
@@ -244,14 +247,13 @@ update scripts msg model =
                 |> maybe_update idx model
 
         Resize code height ->
-            ( case code of
-                Evaluate id ->
-                    { model | evaluate = onResize id height model.evaluate }
+            Return.value <|
+                case code of
+                    Evaluate id ->
+                        { model | evaluate = onResize id height model.evaluate }
 
-                Highlight id ->
-                    { model | highlight = onResize id height model.highlight }
-            , []
-            )
+                    Highlight id ->
+                        { model | highlight = onResize id height model.highlight }
 
         UpdateTerminal idx childMsg ->
             model
@@ -298,44 +300,40 @@ maybe_project idx f =
         >> Maybe.map f
 
 
-maybe_update : Int -> Model -> Maybe ( Project, List Event ) -> ( Model, List Event )
+maybe_update : Int -> Model -> Maybe ( Project, List Event ) -> Return Model Never sub
 maybe_update idx model project =
     case project of
         Just ( p, logs ) ->
-            ( { model | evaluate = Array.set idx p model.evaluate }
-            , if logs == [] then
-                []
-
-              else
-                logs
-            )
+            { model | evaluate = Array.set idx p model.evaluate }
+                |> Return.value
+                |> Return.events logs
 
         _ ->
-            ( model, [] )
+            Return.value model
 
 
-update_file : Int -> Int -> Model -> (File -> File) -> (File -> List Event) -> ( Model, List Event )
+update_file : Int -> Int -> Model -> (File -> File) -> (File -> List Event) -> Return Model Never sub
 update_file id_1 id_2 model f f_log =
     case Array.get id_1 model.evaluate of
         Just project ->
             case project.file |> Array.get id_2 |> Maybe.map f of
                 Just file ->
-                    ( { model
+                    { model
                         | evaluate =
                             Array.set id_1
                                 { project
                                     | file = Array.set id_2 file project.file
                                 }
                                 model.evaluate
-                      }
-                    , f_log file
-                    )
+                    }
+                        |> Return.value
+                        |> Return.events (f_log file)
 
                 Nothing ->
-                    ( model, [] )
+                    Return.value model
 
         Nothing ->
-            ( model, [] )
+            Return.value model
 
 
 is_version_new : Int -> ( Project, List Event ) -> ( Project, List Event )

--- a/src/elm/Lia/Markdown/Code/Update.elm
+++ b/src/elm/Lia/Markdown/Code/Update.elm
@@ -48,12 +48,12 @@ restore json model =
     of
         Ok (Just vector) ->
             Json.merge model vector
-                |> Return.value
+                |> Return.val
 
         Ok Nothing ->
             model
-                |> Return.value
-                |> Return.events
+                |> Return.val
+                |> Return.batchEvents
                     (if Array.length model.evaluate == 0 then
                         []
 
@@ -63,7 +63,7 @@ restore json model =
 
         Err _ ->
             model
-                |> Return.value
+                |> Return.val
 
 
 update : Scripts a -> Msg -> Model -> Return Model msg sub
@@ -107,7 +107,7 @@ update scripts msg model =
                         )
                         model.highlight
             }
-                |> Return.value
+                |> Return.val
 
         FlipFullscreen (Highlight id_1) id_2 ->
             { model
@@ -125,7 +125,7 @@ update scripts msg model =
                         )
                         model.highlight
             }
-                |> Return.value
+                |> Return.val
 
         FlipFullscreen (Evaluate id_1) id_2 ->
             update_file
@@ -238,7 +238,7 @@ update scripts msg model =
                         |> maybe_update event.section model
 
                 _ ->
-                    Return.value model
+                    Return.val model
 
         Stop idx ->
             model
@@ -247,7 +247,7 @@ update scripts msg model =
                 |> maybe_update idx model
 
         Resize code height ->
-            Return.value <|
+            Return.val <|
                 case code of
                     Evaluate id ->
                         { model | evaluate = onResize id height model.evaluate }
@@ -305,11 +305,11 @@ maybe_update idx model project =
     case project of
         Just ( p, logs ) ->
             { model | evaluate = Array.set idx p model.evaluate }
-                |> Return.value
-                |> Return.events logs
+                |> Return.val
+                |> Return.batchEvents logs
 
         _ ->
-            Return.value model
+            Return.val model
 
 
 update_file : Int -> Int -> Model -> (File -> File) -> (File -> List Event) -> Return Model msg sub
@@ -326,14 +326,14 @@ update_file id_1 id_2 model f f_log =
                                 }
                                 model.evaluate
                     }
-                        |> Return.value
-                        |> Return.events (f_log file)
+                        |> Return.val
+                        |> Return.batchEvents (f_log file)
 
                 Nothing ->
-                    Return.value model
+                    Return.val model
 
         Nothing ->
-            Return.value model
+            Return.val model
 
 
 is_version_new : Int -> ( Project, List Event ) -> ( Project, List Event )

--- a/src/elm/Lia/Markdown/Config.elm
+++ b/src/elm/Lia/Markdown/Config.elm
@@ -7,7 +7,7 @@ module Lia.Markdown.Config exposing
 import Dict exposing (Dict)
 import Html exposing (Html)
 import Lia.Markdown.Effect.Model as Effect
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script
 import Lia.Markdown.Inline.Config as Inline
 import Lia.Markdown.Inline.Types exposing (Inlines)
 import Lia.Markdown.Inline.View exposing (viewer)

--- a/src/elm/Lia/Markdown/Effect/Script/Types.elm
+++ b/src/elm/Lia/Markdown/Effect/Script/Types.elm
@@ -1,5 +1,6 @@
 module Lia.Markdown.Effect.Script.Types exposing
-    ( Script
+    ( Msg(..)
+    , Script
     , Scripts
     , Stdout(..)
     , count
@@ -20,6 +21,7 @@ import Lia.Markdown.Effect.Script.Input as Input exposing (Input)
 import Lia.Markdown.Effect.Script.Intl as Intl exposing (Intl)
 import Lia.Markdown.HTML.Attributes as Attr exposing (Parameters)
 import Port.Eval as Eval
+import Port.Event exposing (Event)
 import Regex
 
 
@@ -32,6 +34,21 @@ type Stdout a
     | Text String
     | HTML String
     | IFrame a
+
+
+type Msg sub
+    = Click Int
+    | Reset Int
+    | Activate Bool Int
+    | Value Int Bool String
+    | Radio Int Bool String
+    | Checkbox Int Bool String
+    | Edit Bool Int
+    | EditCode Int String
+    | NoOp
+    | Handle Event
+    | Delay Float (Msg sub)
+    | Sub Int sub
 
 
 isError : Stdout a -> Bool

--- a/src/elm/Lia/Markdown/Effect/Script/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Script/Update.elm
@@ -34,17 +34,11 @@ update main msg scripts =
         Sub id sub ->
             case scripts |> Array.get id |> Maybe.andThen .result of
                 Just (IFrame lia) ->
-                    let
-                        return =
-                            main.update scripts sub lia
-                    in
-                    Script.set id (\s -> { s | result = Just (IFrame return.value) }) scripts
-                        |> Return.value
-                        |> Return.cmd (Cmd.map (Sub id) return.cmd)
-                        |> Return.events
-                            (return.events
-                                |> List.map (Event.encode >> Event "sub" id)
-                            )
+                    lia
+                        |> main.update scripts sub
+                        |> Return.map (\v -> Script.set id (\s -> { s | result = Just (IFrame v) }) scripts)
+                        |> Return.cmdMap (Sub id)
+                        |> Return.upgrade "sub" id
 
                 _ ->
                     Return.value scripts
@@ -251,14 +245,11 @@ update main msg scripts =
                 "sub" ->
                     case scripts |> Array.get event.section |> Maybe.andThen .result of
                         Just (IFrame lia) ->
-                            let
-                                return =
-                                    main.handle scripts event.message lia
-                            in
-                            Script.set event.section (\s -> { s | result = Just (IFrame return.value) }) scripts
-                                |> Return.value
-                                |> Return.cmd (Cmd.map (Sub event.section) return.cmd)
-                                |> Return.events (List.map (Event.encode >> Event "sub" event.section) return.events)
+                            lia
+                                |> main.handle scripts event.message
+                                |> Return.map (\v -> Script.set event.section (\s -> { s | result = Just (IFrame v) }) scripts)
+                                |> Return.cmdMap (Sub event.section)
+                                |> Return.upgrade "sub" event.section
 
                         _ ->
                             Return.value scripts

--- a/src/elm/Lia/Markdown/Effect/Script/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Script/Update.elm
@@ -1,6 +1,5 @@
 module Lia.Markdown.Effect.Script.Update exposing
-    ( Msg(..)
-    , execute
+    ( execute
     , getAll
     , getVisible
     , setRunning
@@ -11,7 +10,7 @@ import Array
 import Json.Encode as JE
 import Lia.Definition.Types exposing (Definition)
 import Lia.Markdown.Effect.Script.Input as Input
-import Lia.Markdown.Effect.Script.Types as Script exposing (Script, Scripts, Stdout(..))
+import Lia.Markdown.Effect.Script.Types as Script exposing (Msg(..), Script, Scripts, Stdout(..))
 import Lia.Parser.Parser exposing (parse_subsection)
 import Lia.Section exposing (SubSection)
 import Lia.Utils exposing (focus)
@@ -19,21 +18,6 @@ import Port.Eval as Eval exposing (Eval)
 import Port.Event as Event exposing (Event)
 import Process
 import Task
-
-
-type Msg sub
-    = Click Int
-    | Reset Int
-    | Activate Bool Int
-    | Value Int Bool String
-    | Radio Int Bool String
-    | Checkbox Int Bool String
-    | Edit Bool Int
-    | EditCode Int String
-    | NoOp
-    | Handle Event
-    | Delay Float (Msg sub)
-    | Sub Int sub
 
 
 update :

--- a/src/elm/Lia/Markdown/Effect/Script/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Script/Update.elm
@@ -36,8 +36,7 @@ update main msg scripts =
                 Just (IFrame lia) ->
                     lia
                         |> main.update scripts sub
-                        |> Return.mapVal (\v -> Script.set id (\s -> { s | result = Just (IFrame v) }) scripts)
-                        |> Return.mapCmd (Sub id)
+                        |> Return.mapValCmd (\v -> Script.set id (\s -> { s | result = Just (IFrame v) }) scripts) (Sub id)
                         |> Return.mapEvents "sub" id
 
                 _ ->
@@ -247,8 +246,7 @@ update main msg scripts =
                         Just (IFrame lia) ->
                             lia
                                 |> main.handle scripts event.message
-                                |> Return.mapVal (\v -> Script.set event.section (\s -> { s | result = Just (IFrame v) }) scripts)
-                                |> Return.mapCmd (Sub event.section)
+                                |> Return.mapValCmd (\v -> Script.set event.section (\s -> { s | result = Just (IFrame v) }) scripts) (Sub event.section)
                                 |> Return.mapEvents "sub" event.section
 
                         _ ->

--- a/src/elm/Lia/Markdown/Effect/Script/View.elm
+++ b/src/elm/Lia/Markdown/Effect/Script/View.elm
@@ -9,8 +9,7 @@ import Json.Encode as JE
 import Lia.Markdown.Code.Editor as Editor
 import Lia.Markdown.Effect.Script.Input as Input exposing (Input)
 import Lia.Markdown.Effect.Script.Intl as Intl
-import Lia.Markdown.Effect.Script.Types exposing (Script, Stdout(..), isError)
-import Lia.Markdown.Effect.Script.Update exposing (Msg(..))
+import Lia.Markdown.Effect.Script.Types exposing (Msg(..), Script, Stdout(..), isError)
 import Lia.Markdown.HTML.Attributes exposing (Parameters, annotation, toAttribute)
 import Lia.Markdown.Inline.Config exposing (Config)
 import Lia.Section exposing (SubSection(..))

--- a/src/elm/Lia/Markdown/Effect/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Update.elm
@@ -41,8 +41,8 @@ type Msg sub
 
 
 updateSub :
-    { update : Scripts SubSection -> sub -> SubSection -> ( SubSection, Cmd sub, List ( String, JE.Value ) )
-    , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List ( String, JE.Value ) )
+    { update : Scripts SubSection -> sub -> SubSection -> ( SubSection, Cmd sub, List Event )
+    , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List Event )
     , globals : Maybe Definition
     }
     -> Script_.Msg sub
@@ -53,8 +53,8 @@ updateSub main msg =
 
 
 update :
-    { update : Scripts SubSection -> sub -> SubSection -> ( SubSection, Cmd sub, List ( String, JE.Value ) )
-    , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List ( String, JE.Value ) )
+    { update : Scripts SubSection -> sub -> SubSection -> ( SubSection, Cmd sub, List Event )
+    , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List Event )
     , globals : Maybe Definition
     }
     -> Bool
@@ -177,8 +177,8 @@ markRunning ( model, cmd, events ) =
 
 
 execute :
-    { update : Scripts SubSection -> sub -> SubSection -> ( SubSection, Cmd sub, List ( String, JE.Value ) )
-    , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List ( String, JE.Value ) )
+    { update : Scripts SubSection -> sub -> SubSection -> ( SubSection, Cmd sub, List Event )
+    , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List Event )
     , globals : Maybe Definition
     }
     -> Bool

--- a/src/elm/Lia/Markdown/Effect/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Update.elm
@@ -42,8 +42,8 @@ type Msg sub
 
 
 updateSub :
-    { update : Scripts SubSection -> sub -> SubSection -> ( SubSection, Cmd sub, List Event )
-    , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List Event )
+    { update : Scripts SubSection -> sub -> SubSection -> Return SubSection sub sub
+    , handle : Scripts SubSection -> JE.Value -> SubSection -> Return SubSection sub sub
     , globals : Maybe Definition
     }
     -> Script_.Msg sub
@@ -54,8 +54,8 @@ updateSub main msg =
 
 
 update :
-    { update : Scripts SubSection -> sub -> SubSection -> ( SubSection, Cmd sub, List Event )
-    , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List Event )
+    { update : Scripts SubSection -> sub -> SubSection -> Return SubSection sub sub
+    , handle : Scripts SubSection -> JE.Value -> SubSection -> Return SubSection sub sub
     , globals : Maybe Definition
     }
     -> Bool
@@ -185,8 +185,8 @@ markRunning return =
 
 
 execute :
-    { update : Scripts SubSection -> sub -> SubSection -> ( SubSection, Cmd sub, List Event )
-    , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List Event )
+    { update : Scripts SubSection -> sub -> SubSection -> Return SubSection sub sub
+    , handle : Scripts SubSection -> JE.Value -> SubSection -> Return SubSection sub sub
     , globals : Maybe Definition
     }
     -> Bool

--- a/src/elm/Lia/Markdown/Effect/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Update.elm
@@ -119,8 +119,7 @@ update main sound msg model =
             Script childMsg ->
                 model.javascript
                     |> Script.update main childMsg
-                    |> Return.mapVal (\v -> { model | javascript = v })
-                    |> Return.mapCmd Script
+                    |> Return.mapValCmd (\v -> { model | javascript = v }) Script
 
             Handle event ->
                 case event.topic of
@@ -139,8 +138,7 @@ update main sound msg model =
                     _ ->
                         model.javascript
                             |> Script.update main (Script_.Handle event)
-                            |> Return.mapVal (\v -> { model | javascript = v })
-                            |> Return.mapCmd Script
+                            |> Return.mapValCmd (\v -> { model | javascript = v }) Script
 
 
 scrollTo : Bool -> String -> Event

--- a/src/elm/Lia/Markdown/Effect/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Update.elm
@@ -118,10 +118,10 @@ update main sound msg model =
 
             Script childMsg ->
                 let
-                    ( scripts, cmd, events ) =
+                    return =
                         Script.update main childMsg model.javascript
                 in
-                ( { model | javascript = scripts }, Cmd.map Script cmd, events )
+                ( { model | javascript = return.value }, Cmd.map Script return.cmd, return.events )
 
             Handle event ->
                 case event.topic of
@@ -138,10 +138,10 @@ update main sound msg model =
 
                     _ ->
                         let
-                            ( scripts, cmd, events ) =
+                            return =
                                 Script.update main (Script_.Handle event) model.javascript
                         in
-                        ( { model | javascript = scripts }, Cmd.map Script cmd, events )
+                        ( { model | javascript = return.value }, Cmd.map Script return.cmd, return.events )
 
 
 scrollTo : Bool -> String -> Event

--- a/src/elm/Lia/Markdown/Effect/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Update.elm
@@ -21,7 +21,7 @@ import Lia.Markdown.Effect.Model
         ( Model
         , current_comment
         )
-import Lia.Markdown.Effect.Script.Types exposing (Scripts)
+import Lia.Markdown.Effect.Script.Types as Script_ exposing (Scripts)
 import Lia.Markdown.Effect.Script.Update as Script
 import Lia.Section exposing (SubSection)
 import Port.Event exposing (Event)
@@ -37,7 +37,7 @@ type Msg sub
     | Mute Int
     | Rendered Bool Dom.Viewport
     | Handle Event
-    | Script (Script.Msg sub)
+    | Script (Script_.Msg sub)
 
 
 updateSub :
@@ -45,7 +45,7 @@ updateSub :
     , handle : Scripts SubSection -> JE.Value -> SubSection -> ( SubSection, Cmd sub, List ( String, JE.Value ) )
     , globals : Maybe Definition
     }
-    -> Script.Msg sub
+    -> Script_.Msg sub
     -> Model SubSection
     -> ( Model SubSection, Cmd (Msg sub), List Event )
 updateSub main msg =
@@ -139,7 +139,7 @@ update main sound msg model =
                     _ ->
                         let
                             ( scripts, cmd, events ) =
-                                Script.update main (Script.Handle event) model.javascript
+                                Script.update main (Script_.Handle event) model.javascript
                         in
                         ( { model | javascript = scripts }, Cmd.map Script cmd, events )
 

--- a/src/elm/Lia/Markdown/Effect/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Update.elm
@@ -117,14 +117,10 @@ update main sound msg model =
                 execute main sound run_all_javascript 0 model
 
             Script childMsg ->
-                let
-                    return =
-                        Script.update main childMsg model.javascript
-                in
-                { model | javascript = return.value }
-                    |> Return.value
-                    |> Return.cmd (Cmd.map Script return.cmd)
-                    |> Return.events return.events
+                model.javascript
+                    |> Script.update main childMsg
+                    |> Return.map (\v -> { model | javascript = v })
+                    |> Return.cmdMap Script
 
             Handle event ->
                 case event.topic of
@@ -141,14 +137,10 @@ update main sound msg model =
                                     model
 
                     _ ->
-                        let
-                            return =
-                                Script.update main (Script_.Handle event) model.javascript
-                        in
-                        { model | javascript = return.value }
-                            |> Return.value
-                            |> Return.cmd (Cmd.map Script return.cmd)
-                            |> Return.events return.events
+                        model.javascript
+                            |> Script.update main (Script_.Handle event)
+                            |> Return.map (\v -> { model | javascript = v })
+                            |> Return.cmdMap Script
 
 
 scrollTo : Bool -> String -> Event

--- a/src/elm/Lia/Markdown/Effect/Update.elm
+++ b/src/elm/Lia/Markdown/Effect/Update.elm
@@ -67,7 +67,7 @@ update main sound msg model =
         case msg of
             Init run_all_javascript ->
                 model
-                    |> Return.value
+                    |> Return.val
                     |> Return.cmd (Task.perform (Rendered run_all_javascript) Dom.getViewport)
 
             Next ->
@@ -76,7 +76,7 @@ update main sound msg model =
                         |> execute main sound False 0
 
                 else
-                    Return.value model
+                    Return.val model
 
             Previous ->
                 if has_previous model then
@@ -84,12 +84,12 @@ update main sound msg model =
                         |> execute main sound False 0
 
                 else
-                    Return.value model
+                    Return.val model
 
             Mute id ->
                 { model | speaking = Nothing }
-                    |> Return.value
-                    |> Return.event (TTS.mute id)
+                    |> Return.val
+                    |> Return.batchEvent (TTS.mute id)
 
             Send event ->
                 let
@@ -99,8 +99,8 @@ update main sound msg model =
                             :: event
                 in
                 model
-                    |> Return.value
-                    |> Return.events
+                    |> Return.val
+                    |> Return.batchEvents
                         (case current_comment model of
                             Just ( id, _ ) ->
                                 if sound then
@@ -119,13 +119,13 @@ update main sound msg model =
             Script childMsg ->
                 model.javascript
                     |> Script.update main childMsg
-                    |> Return.map (\v -> { model | javascript = v })
-                    |> Return.cmdMap Script
+                    |> Return.mapVal (\v -> { model | javascript = v })
+                    |> Return.mapCmd Script
 
             Handle event ->
                 case event.topic of
                     "speak" ->
-                        Return.value <|
+                        Return.val <|
                             case event.message |> JD.decodeValue JD.string of
                                 Ok "start" ->
                                     { model | speaking = Just event.section }
@@ -139,8 +139,8 @@ update main sound msg model =
                     _ ->
                         model.javascript
                             |> Script.update main (Script_.Handle event)
-                            |> Return.map (\v -> { model | javascript = v })
-                            |> Return.cmdMap Script
+                            |> Return.mapVal (\v -> { model | javascript = v })
+                            |> Return.mapCmd Script
 
 
 scrollTo : Bool -> String -> Event
@@ -158,7 +158,7 @@ scrollTo force =
 markRunning : Return (Model a) (Msg sub) sub -> Return (Model a) (Msg sub) sub
 markRunning return =
     return
-        |> Return.map
+        |> Return.mapVal
             (\model ->
                 { model
                     | javascript =

--- a/src/elm/Lia/Markdown/Gallery/Update.elm
+++ b/src/elm/Lia/Markdown/Gallery/Update.elm
@@ -15,7 +15,7 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Msg sub -> Vector -> Return Vector Never sub
+update : Msg sub -> Vector -> Return Vector msg sub
 update msg vector =
     case msg of
         Show id id2 ->

--- a/src/elm/Lia/Markdown/Gallery/Update.elm
+++ b/src/elm/Lia/Markdown/Gallery/Update.elm
@@ -4,7 +4,7 @@ module Lia.Markdown.Gallery.Update exposing
     )
 
 import Array
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script
 import Lia.Markdown.Gallery.Types exposing (Vector)
 import Return exposing (Return)
 

--- a/src/elm/Lia/Markdown/Gallery/Update.elm
+++ b/src/elm/Lia/Markdown/Gallery/Update.elm
@@ -6,6 +6,7 @@ module Lia.Markdown.Gallery.Update exposing
 import Array
 import Lia.Markdown.Effect.Script.Update as Script
 import Lia.Markdown.Gallery.Types exposing (Vector)
+import Return exposing (Return)
 
 
 type Msg sub
@@ -14,14 +15,20 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Msg sub -> Vector -> ( Vector, Maybe (Script.Msg sub) )
+update : Msg sub -> Vector -> Return Vector Never sub
 update msg vector =
     case msg of
         Show id id2 ->
-            ( Array.set id id2 vector, Nothing )
+            vector
+                |> Array.set id id2
+                |> Return.value
 
         Close id ->
-            ( Array.set id -1 vector, Nothing )
+            vector
+                |> Array.set id -1
+                |> Return.value
 
         Script sub ->
-            ( vector, Just sub )
+            vector
+                |> Return.value
+                |> Return.script sub

--- a/src/elm/Lia/Markdown/Gallery/Update.elm
+++ b/src/elm/Lia/Markdown/Gallery/Update.elm
@@ -21,14 +21,14 @@ update msg vector =
         Show id id2 ->
             vector
                 |> Array.set id id2
-                |> Return.value
+                |> Return.val
 
         Close id ->
             vector
                 |> Array.set id -1
-                |> Return.value
+                |> Return.val
 
         Script sub ->
             vector
-                |> Return.value
+                |> Return.val
                 |> Return.script sub

--- a/src/elm/Lia/Markdown/Inline/Config.elm
+++ b/src/elm/Lia/Markdown/Inline/Config.elm
@@ -6,8 +6,7 @@ module Lia.Markdown.Inline.Config exposing
 
 import Dict exposing (Dict)
 import Html exposing (Html)
-import Lia.Markdown.Effect.Script.Types exposing (Scripts)
-import Lia.Markdown.Effect.Script.Update exposing (Msg)
+import Lia.Markdown.Effect.Script.Types exposing (Msg, Scripts)
 import Lia.Section exposing (SubSection)
 import Lia.Settings.Types exposing (Mode(..))
 import Translations exposing (Lang)

--- a/src/elm/Lia/Markdown/Inline/View.elm
+++ b/src/elm/Lia/Markdown/Inline/View.elm
@@ -12,8 +12,7 @@ import Dict exposing (Dict)
 import Html exposing (Attribute, Html)
 import Html.Attributes as Attr exposing (width)
 import Json.Encode as JE
-import Lia.Markdown.Effect.Script.Types exposing (Scripts)
-import Lia.Markdown.Effect.Script.Update exposing (Msg)
+import Lia.Markdown.Effect.Script.Types exposing (Msg, Scripts)
 import Lia.Markdown.Effect.Script.View as JS
 import Lia.Markdown.Effect.View as Effect
 import Lia.Markdown.Footnote.View as Footnote

--- a/src/elm/Lia/Markdown/Quiz/Block/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Block/Update.elm
@@ -4,7 +4,7 @@ module Lia.Markdown.Quiz.Block.Update exposing
     , update
     )
 
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script
 import Lia.Markdown.Quiz.Block.Types exposing (State(..))
 import Return exposing (Return)
 

--- a/src/elm/Lia/Markdown/Quiz/Block/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Block/Update.elm
@@ -21,24 +21,24 @@ update msg state =
     case ( msg, state ) of
         ( Choose option, Select _ _ ) ->
             Select True [ option ]
-                |> Return.value
+                |> Return.val
 
         ( Toggle, Select open id ) ->
             Select (not open) id
-                |> Return.value
+                |> Return.val
 
         ( Input str, Text _ ) ->
             Text str
-                |> Return.value
+                |> Return.val
 
         ( Script sub, _ ) ->
             state
-                |> Return.value
+                |> Return.val
                 |> Return.script sub
 
         _ ->
             state
-                |> Return.value
+                |> Return.val
 
 
 toString : State -> String

--- a/src/elm/Lia/Markdown/Quiz/Block/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Block/Update.elm
@@ -16,7 +16,7 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Msg sub -> State -> Return State Never sub
+update : Msg sub -> State -> Return State msg sub
 update msg state =
     case ( msg, state ) of
         ( Choose option, Select _ _ ) ->

--- a/src/elm/Lia/Markdown/Quiz/Block/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Block/Update.elm
@@ -6,6 +6,7 @@ module Lia.Markdown.Quiz.Block.Update exposing
 
 import Lia.Markdown.Effect.Script.Update as Script
 import Lia.Markdown.Quiz.Block.Types exposing (State(..))
+import Return exposing (Return)
 
 
 type Msg sub
@@ -15,23 +16,29 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Msg sub -> State -> ( State, Maybe (Script.Msg sub) )
+update : Msg sub -> State -> Return State Never sub
 update msg state =
     case ( msg, state ) of
         ( Choose option, Select _ _ ) ->
-            ( Select True [ option ], Nothing )
+            Select True [ option ]
+                |> Return.value
 
         ( Toggle, Select open id ) ->
-            ( Select (not open) id, Nothing )
+            Select (not open) id
+                |> Return.value
 
         ( Input str, Text _ ) ->
-            ( Text str, Nothing )
+            Text str
+                |> Return.value
 
         ( Script sub, _ ) ->
-            ( state, Just sub )
+            state
+                |> Return.value
+                |> Return.script sub
 
         _ ->
-            ( state, Nothing )
+            state
+                |> Return.value
 
 
 toString : State -> String

--- a/src/elm/Lia/Markdown/Quiz/Matrix/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Matrix/Update.elm
@@ -1,7 +1,7 @@
 module Lia.Markdown.Quiz.Matrix.Update exposing (Msg(..), toString, update)
 
 import Array
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script
 import Lia.Markdown.Quiz.Matrix.Types exposing (State)
 import Lia.Markdown.Quiz.Vector.Update as Vector
 import Return exposing (Return)

--- a/src/elm/Lia/Markdown/Quiz/Matrix/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Matrix/Update.elm
@@ -12,7 +12,7 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Msg sub -> State -> Return State Never sub
+update : Msg sub -> State -> Return State msg sub
 update msg state =
     case msg of
         Toggle row_id column_id ->

--- a/src/elm/Lia/Markdown/Quiz/Matrix/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Matrix/Update.elm
@@ -4,6 +4,7 @@ import Array
 import Lia.Markdown.Effect.Script.Update as Script
 import Lia.Markdown.Quiz.Matrix.Types exposing (State)
 import Lia.Markdown.Quiz.Vector.Update as Vector
+import Return exposing (Return)
 
 
 type Msg sub
@@ -11,23 +12,26 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Msg sub -> State -> ( State, Maybe (Script.Msg sub) )
+update : Msg sub -> State -> Return State Never sub
 update msg state =
     case msg of
         Toggle row_id column_id ->
-            case
-                state
-                    |> Array.get row_id
-                    |> Maybe.map (Vector.toggle column_id)
-            of
-                Just row ->
-                    ( Array.set row_id row state, Nothing )
+            Return.value <|
+                case
+                    state
+                        |> Array.get row_id
+                        |> Maybe.map (Vector.toggle column_id)
+                of
+                    Just row ->
+                        Array.set row_id row state
 
-                _ ->
-                    ( state, Nothing )
+                    _ ->
+                        state
 
         Script sub ->
-            ( state, Just sub )
+            state
+                |> Return.value
+                |> Return.script sub
 
 
 toString : State -> String

--- a/src/elm/Lia/Markdown/Quiz/Matrix/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Matrix/Update.elm
@@ -16,7 +16,7 @@ update : Msg sub -> State -> Return State msg sub
 update msg state =
     case msg of
         Toggle row_id column_id ->
-            Return.value <|
+            Return.val <|
                 case
                     state
                         |> Array.get row_id
@@ -30,7 +30,7 @@ update msg state =
 
         Script sub ->
             state
-                |> Return.value
+                |> Return.val
                 |> Return.script sub
 
 

--- a/src/elm/Lia/Markdown/Quiz/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Update.elm
@@ -121,7 +121,7 @@ get idx vector =
 update_ :
     Int
     -> Vector
-    -> (Element -> Return Element Never sub)
+    -> (Element -> Return Element msg sub)
     -> Return Vector msg sub
 update_ idx vector fn =
     Return.value <|
@@ -133,7 +133,7 @@ update_ idx vector fn =
                 vector
 
 
-state_ : Msg sub -> Element -> Return Element Never sub
+state_ : Msg sub -> Element -> Return Element msg sub
 state_ msg e =
     case ( msg, e.state ) of
         ( Block_Update _ m, Block_State s ) ->

--- a/src/elm/Lia/Markdown/Quiz/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Update.elm
@@ -2,8 +2,7 @@ module Lia.Markdown.Quiz.Update exposing (Msg(..), handle, update)
 
 import Array
 import Json.Encode as JE
-import Lia.Markdown.Effect.Script.Types exposing (Scripts, outputs)
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script exposing (Scripts, outputs)
 import Lia.Markdown.Quiz.Block.Update as Block
 import Lia.Markdown.Quiz.Json as Json
 import Lia.Markdown.Quiz.Matrix.Update as Matrix

--- a/src/elm/Lia/Markdown/Quiz/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Update.elm
@@ -25,7 +25,7 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Scripts a -> Msg sub -> Vector -> Return Vector Never sub
+update : Scripts a -> Msg sub -> Vector -> Return Vector msg sub
 update scripts msg vector =
     case msg of
         Block_Update id _ ->
@@ -122,7 +122,7 @@ update_ :
     Int
     -> Vector
     -> (Element -> Return Element Never sub)
-    -> Return Vector Never sub
+    -> Return Vector msg sub
 update_ idx vector fn =
     Return.value <|
         case get idx vector |> Maybe.map fn of
@@ -165,7 +165,7 @@ handle =
     Handle
 
 
-evalEventDecoder : JE.Value -> Element -> Return Element Never sub
+evalEventDecoder : JE.Value -> Element -> Return Element msg sub
 evalEventDecoder json =
     let
         eval =
@@ -199,7 +199,7 @@ evalEventDecoder json =
         \e -> Return.value { e | error_msg = eval.result }
 
 
-store : Return Vector Never sub -> Return Vector Never sub
+store : Return Vector msg sub -> Return Vector msg sub
 store return =
     return
         |> Return.event
@@ -209,7 +209,7 @@ store return =
             )
 
 
-check : Type -> Element -> Return Element Never sub
+check : Type -> Element -> Return Element msg sub
 check solution e =
     { e
         | trial = e.trial + 1

--- a/src/elm/Lia/Markdown/Quiz/Vector/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Vector/Update.elm
@@ -7,6 +7,7 @@ module Lia.Markdown.Quiz.Vector.Update exposing
 
 import Lia.Markdown.Effect.Script.Update as Script
 import Lia.Markdown.Quiz.Vector.Types exposing (State(..))
+import Return exposing (Return)
 
 
 type Msg sub
@@ -14,14 +15,18 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Msg sub -> State -> ( State, Maybe (Script.Msg sub) )
+update : Msg sub -> State -> Return State Never sub
 update msg state =
     case msg of
         Toggle id ->
-            ( toggle id state, Nothing )
+            state
+                |> toggle id
+                |> Return.value
 
         Script sub ->
-            ( state, Just sub )
+            state
+                |> Return.value
+                |> Return.script sub
 
 
 toggle : Int -> State -> State

--- a/src/elm/Lia/Markdown/Quiz/Vector/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Vector/Update.elm
@@ -15,7 +15,7 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Msg sub -> State -> Return State Never sub
+update : Msg sub -> State -> Return State msg sub
 update msg state =
     case msg of
         Toggle id ->

--- a/src/elm/Lia/Markdown/Quiz/Vector/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Vector/Update.elm
@@ -5,7 +5,7 @@ module Lia.Markdown.Quiz.Vector.Update exposing
     , update
     )
 
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script
 import Lia.Markdown.Quiz.Vector.Types exposing (State(..))
 import Return exposing (Return)
 

--- a/src/elm/Lia/Markdown/Quiz/Vector/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Vector/Update.elm
@@ -21,11 +21,11 @@ update msg state =
         Toggle id ->
             state
                 |> toggle id
-                |> Return.value
+                |> Return.val
 
         Script sub ->
             state
-                |> Return.value
+                |> Return.val
                 |> Return.script sub
 
 

--- a/src/elm/Lia/Markdown/Quiz/Vector/View.elm
+++ b/src/elm/Lia/Markdown/Quiz/Vector/View.elm
@@ -1,7 +1,6 @@
 module Lia.Markdown.Quiz.Vector.View exposing (view)
 
 import Accessibility.Role as A11y_Role
-import Accessibility.Widget as A11y_Widget
 import Html exposing (Attribute, Html)
 import Html.Attributes as Attr
 import Html.Events exposing (onClick)

--- a/src/elm/Lia/Markdown/Quiz/Vector/View.elm
+++ b/src/elm/Lia/Markdown/Quiz/Vector/View.elm
@@ -25,10 +25,10 @@ view config open class quiz state =
 
 
 table : (Bool -> ( Int, Inlines ) -> Html (Msg sub)) -> List Inlines -> List Bool -> List (Html (Msg sub))
-table fn inlines bools =
+table fn inlines bool =
     inlines
         |> List.indexedMap Tuple.pair
-        |> List.map2 fn bools
+        |> List.map2 fn bool
 
 
 check : Config sub -> Bool -> String -> Bool -> ( Int, Inlines ) -> Html (Msg sub)

--- a/src/elm/Lia/Markdown/Survey/Update.elm
+++ b/src/elm/Lia/Markdown/Survey/Update.elm
@@ -2,8 +2,7 @@ module Lia.Markdown.Survey.Update exposing (Msg(..), handle, update)
 
 import Array
 import Dict
-import Lia.Markdown.Effect.Script.Types exposing (Scripts, outputs)
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script exposing (Scripts, outputs)
 import Lia.Markdown.Survey.Json as Json
 import Lia.Markdown.Survey.Types exposing (State(..), Vector, toString)
 import Port.Eval as Eval

--- a/src/elm/Lia/Markdown/Survey/Update.elm
+++ b/src/elm/Lia/Markdown/Survey/Update.elm
@@ -22,7 +22,7 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Scripts a -> Msg sub -> Vector -> Return Vector Never sub
+update : Scripts a -> Msg sub -> Vector -> Return Vector msg sub
 update scripts msg vector =
     case msg of
         TextUpdate idx str ->

--- a/src/elm/Lia/Markdown/Survey/Update.elm
+++ b/src/elm/Lia/Markdown/Survey/Update.elm
@@ -27,30 +27,30 @@ update scripts msg vector =
     case msg of
         TextUpdate idx str ->
             update_text vector idx str
-                |> Return.value
+                |> Return.val
 
         SelectUpdate id value ->
             update_select vector id value
-                |> Return.value
+                |> Return.val
 
         SelectChose id ->
             update_select_chose vector id
-                |> Return.value
+                |> Return.val
 
         VectorUpdate idx var ->
             update_vector vector idx var
-                |> Return.value
+                |> Return.val
 
         MatrixUpdate idx row var ->
             update_matrix vector idx row var
-                |> Return.value
+                |> Return.val
 
         KeyDown id javascript char ->
             if char == 13 then
                 update scripts (Submit id javascript) vector
 
             else
-                Return.value vector
+                Return.val vector
 
         Submit id Nothing ->
             if submittable vector id then
@@ -59,8 +59,8 @@ update scripts msg vector =
                         submit vector id
                 in
                 new_vector
-                    |> Return.value
-                    |> Return.event
+                    |> Return.val
+                    |> Return.batchEvent
                         (new_vector
                             |> Json.fromVector
                             |> Event.store
@@ -68,7 +68,7 @@ update scripts msg vector =
 
             else
                 vector
-                    |> Return.value
+                    |> Return.val
 
         Submit id (Just code) ->
             case vector |> Array.get id of
@@ -79,18 +79,18 @@ update scripts msg vector =
                      else
                         updateError vector id Nothing
                     )
-                        |> Return.value
-                        |> Return.event
+                        |> Return.val
+                        |> Return.batchEvent
                             ([ toString state ]
                                 |> Eval.event id code (outputs scripts)
                             )
 
                 _ ->
-                    Return.value vector
+                    Return.val vector
 
         Script sub ->
             vector
-                |> Return.value
+                |> Return.val
                 |> Return.script sub
 
         Handle event ->
@@ -106,19 +106,19 @@ update scripts msg vector =
                     else if eval.result /= "" && not eval.ok then
                         Just eval.result
                             |> updateError vector event.section
-                            |> Return.value
+                            |> Return.val
 
                     else
-                        Return.value vector
+                        Return.val vector
 
                 "restore" ->
                     event.message
                         |> Json.toVector
                         |> Result.withDefault vector
-                        |> Return.value
+                        |> Return.val
 
                 _ ->
-                    Return.value vector
+                    Return.val vector
 
 
 updateError : Vector -> Int -> Maybe String -> Vector

--- a/src/elm/Lia/Markdown/Table/Update.elm
+++ b/src/elm/Lia/Markdown/Table/Update.elm
@@ -16,7 +16,7 @@ type Msg sub
 
 update : Msg sub -> Vector -> Return Vector msg sub
 update msg vector =
-    Return.value <|
+    Return.val <|
         case msg of
             Sort id col ->
                 vector

--- a/src/elm/Lia/Markdown/Table/Update.elm
+++ b/src/elm/Lia/Markdown/Table/Update.elm
@@ -14,7 +14,7 @@ type Msg sub
     | NoOp
 
 
-update : Msg sub -> Vector -> Return Vector Never sub
+update : Msg sub -> Vector -> Return Vector msg sub
 update msg vector =
     Return.value <|
         case msg of

--- a/src/elm/Lia/Markdown/Table/Update.elm
+++ b/src/elm/Lia/Markdown/Table/Update.elm
@@ -5,6 +5,7 @@ module Lia.Markdown.Table.Update exposing
 
 import Array
 import Lia.Markdown.Table.Types exposing (Class(..), State, Vector)
+import Return exposing (Return)
 
 
 type Msg sub
@@ -13,23 +14,24 @@ type Msg sub
     | NoOp
 
 
-update : Msg sub -> Vector -> Vector
+update : Msg sub -> Vector -> Return Vector Never sub
 update msg vector =
-    case msg of
-        Sort id col ->
-            vector
-                |> Array.get id
-                |> Maybe.map (\state -> Array.set id (updateSort col state) vector)
-                |> Maybe.withDefault vector
+    Return.value <|
+        case msg of
+            Sort id col ->
+                vector
+                    |> Array.get id
+                    |> Maybe.map (\state -> Array.set id (updateSort col state) vector)
+                    |> Maybe.withDefault vector
 
-        Toggle id ->
-            vector
-                |> Array.get id
-                |> Maybe.map (\state -> Array.set id { state | diagram = not state.diagram } vector)
-                |> Maybe.withDefault vector
+            Toggle id ->
+                vector
+                    |> Array.get id
+                    |> Maybe.map (\state -> Array.set id { state | diagram = not state.diagram } vector)
+                    |> Maybe.withDefault vector
 
-        NoOp ->
-            vector
+            NoOp ->
+                vector
 
 
 

--- a/src/elm/Lia/Markdown/Task/Update.elm
+++ b/src/elm/Lia/Markdown/Task/Update.elm
@@ -42,7 +42,7 @@ update scripts msg vector =
                 |> Array.get x
                 |> Maybe.map (\state -> Array.set x (toggle y state) vector)
                 |> Maybe.withDefault vector
-                |> Return.value
+                |> Return.val
                 |> store
 
         -- toggle and execute the code snippet
@@ -55,8 +55,8 @@ update scripts msg vector =
                 Just state ->
                     vector
                         |> Array.set x state
-                        |> Return.value
-                        |> Return.event
+                        |> Return.val
+                        |> Return.batchEvent
                             ([ state
                                 |> JE.array JE.bool
                                 |> JE.encode 0
@@ -66,15 +66,15 @@ update scripts msg vector =
                         |> store
 
                 Nothing ->
-                    Return.value vector
+                    Return.val vector
 
         Script sub ->
             vector
-                |> Return.value
+                |> Return.val
                 |> Return.script sub
 
         Handle event ->
-            Return.value <|
+            Return.val <|
                 case event.topic of
                     -- currently it is only possible to restore states from the backend
                     "restore" ->
@@ -104,7 +104,7 @@ within the backend.
 store : Return Vector msg sub -> Return Vector msg sub
 store return =
     return
-        |> Return.event
+        |> Return.batchEvent
             (return.value
                 |> Json.fromVector
                 |> Event.store

--- a/src/elm/Lia/Markdown/Task/Update.elm
+++ b/src/elm/Lia/Markdown/Task/Update.elm
@@ -12,6 +12,7 @@ import Lia.Markdown.Task.Json as Json
 import Lia.Markdown.Task.Types exposing (Vector)
 import Port.Eval as Eval
 import Port.Event as Event exposing (Event)
+import Return exposing (Return)
 
 
 {-| Interaction associated to LiaScript task list:
@@ -29,18 +30,20 @@ type Msg sub
     | Script (Script.Msg sub)
 
 
-update : Scripts a -> Msg sub -> Vector -> ( Vector, List Event, Maybe (Script.Msg sub) )
+update :
+    Scripts a
+    -> Msg sub
+    -> Vector
+    -> Return Vector Never sub
 update scripts msg vector =
     case msg of
         -- simple toggle
         Toggle x y Nothing ->
-            ( vector
+            vector
                 |> Array.get x
                 |> Maybe.map (\state -> Array.set x (toggle y state) vector)
                 |> Maybe.withDefault vector
-            , []
-            , Nothing
-            )
+                |> Return.value
                 |> store
 
         -- toggle and execute the code snippet
@@ -51,37 +54,38 @@ update scripts msg vector =
                     |> Maybe.map (toggle y)
             of
                 Just state ->
-                    ( Array.set x state vector
-                    , [ [ state
-                            |> JE.array JE.bool
-                            |> JE.encode 0
-                        ]
-                            |> Eval.event x code (outputs scripts)
-                      ]
-                    , Nothing
-                    )
+                    vector
+                        |> Array.set x state
+                        |> Return.value
+                        |> Return.event
+                            ([ state
+                                |> JE.array JE.bool
+                                |> JE.encode 0
+                             ]
+                                |> Eval.event x code (outputs scripts)
+                            )
                         |> store
 
                 Nothing ->
-                    ( vector, [], Nothing )
+                    Return.value vector
 
-        Script childMsg ->
-            ( vector, [], Just childMsg )
+        Script sub ->
+            vector
+                |> Return.value
+                |> Return.script sub
 
         Handle event ->
-            case event.topic of
-                -- currently it is only possible to restore states from the backend
-                "restore" ->
-                    ( event.message
-                        |> Json.toVector
-                        |> Result.withDefault vector
-                    , []
-                    , Nothing
-                    )
+            Return.value <|
+                case event.topic of
+                    -- currently it is only possible to restore states from the backend
+                    "restore" ->
+                        event.message
+                            |> Json.toVector
+                            |> Result.withDefault vector
 
-                -- eval events are not handled at the moment
-                _ ->
-                    ( vector, [], Nothing )
+                    -- eval events are not handled at the moment
+                    _ ->
+                        vector
 
 
 toggle : Int -> Array Bool -> Array Bool
@@ -98,16 +102,14 @@ toggle y states =
 {-| Create a store event, that will store the state of the task persistently
 within the backend.
 -}
-store : ( Vector, List Event, Maybe (Script.Msg sub) ) -> ( Vector, List Event, Maybe (Script.Msg sub) )
-store ( vector, events, sub ) =
-    ( vector
-    , (vector
-        |> Json.fromVector
-        |> Event.store
-      )
-        :: events
-    , sub
-    )
+store : Return Vector Never sub -> Return Vector Never sub
+store return =
+    return
+        |> Return.event
+            (return.value
+                |> Json.fromVector
+                |> Event.store
+            )
 
 
 {-| Pass events from parent update function to the Task update function.

--- a/src/elm/Lia/Markdown/Task/Update.elm
+++ b/src/elm/Lia/Markdown/Task/Update.elm
@@ -6,8 +6,7 @@ module Lia.Markdown.Task.Update exposing
 
 import Array exposing (Array)
 import Json.Encode as JE
-import Lia.Markdown.Effect.Script.Types exposing (Scripts, outputs)
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script exposing (Scripts, outputs)
 import Lia.Markdown.Task.Json as Json
 import Lia.Markdown.Task.Types exposing (Vector)
 import Port.Eval as Eval

--- a/src/elm/Lia/Markdown/Task/Update.elm
+++ b/src/elm/Lia/Markdown/Task/Update.elm
@@ -33,7 +33,7 @@ update :
     Scripts a
     -> Msg sub
     -> Vector
-    -> Return Vector Never sub
+    -> Return Vector msg sub
 update scripts msg vector =
     case msg of
         -- simple toggle
@@ -101,7 +101,7 @@ toggle y states =
 {-| Create a store event, that will store the state of the task persistently
 within the backend.
 -}
-store : Return Vector Never sub -> Return Vector Never sub
+store : Return Vector msg sub -> Return Vector msg sub
 store return =
     return
         |> Return.event

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -124,14 +124,14 @@ update globals msg section =
 
         UpdateGallery childMsg ->
             let
-                ( vector, sub ) =
+                return =
                     Gallery.update childMsg section.gallery_vector
             in
-            ( { section | gallery_vector = vector }
+            ( { section | gallery_vector = return.value }
             , Cmd.none
             , []
             )
-                |> updateScript sub
+                |> updateScript return.script
 
         UpdateSurvey childMsg ->
             let

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -59,7 +59,7 @@ update globals msg section =
     case msg of
         UpdateEffect sound childMsg ->
             let
-                ( effect_model, cmd, event ) =
+                return =
                     Effect.update
                         { update = subUpdate
                         , handle = subHandle
@@ -75,9 +75,9 @@ update globals msg section =
                         childMsg
                         section.effect_model
             in
-            ( { section | effect_model = effect_model }
-            , Cmd.map (UpdateEffect sound) cmd
-            , event
+            ( { section | effect_model = return.value }
+            , Cmd.map (UpdateEffect sound) return.cmd
+            , return.events
                 |> send "effect" section.id
             )
 
@@ -178,12 +178,12 @@ subUpdate js msg section =
             case msg of
                 UpdateEffect sound childMsg ->
                     let
-                        ( effect_model, cmd, event ) =
+                        return =
                             Effect.update { update = subUpdate, handle = subHandle, globals = Nothing } sound childMsg subsection.effect_model
                     in
-                    ( SubSection { subsection | effect_model = effect_model }
-                    , Cmd.map (UpdateEffect sound) cmd
-                    , event
+                    ( SubSection { subsection | effect_model = return.value }
+                    , Cmd.map (UpdateEffect sound) return.cmd
+                    , return.events
                         |> send "effect" subsection.id
                     )
 
@@ -264,12 +264,13 @@ subUpdate js msg section =
 
                 Script childMsg ->
                     let
-                        ( effect_model, cmd, _ ) =
+                        return =
                             Effect.updateSub { update = subUpdate, handle = subHandle, globals = Nothing } childMsg subsection.effect_model
                     in
-                    ( SubSection { subsection | effect_model = effect_model }
-                    , Cmd.map (UpdateEffect True) cmd
-                    , []
+                    ( SubSection { subsection | effect_model = return.value }
+                    , Cmd.map (UpdateEffect True) return.cmd
+                    , return.events
+                        |> send "script" subsection.id
                     )
 
                 _ ->
@@ -279,22 +280,23 @@ subUpdate js msg section =
             case msg of
                 Script childMsg ->
                     let
-                        ( effect_model, cmd, _ ) =
+                        return =
                             Effect.updateSub { update = subUpdate, handle = subHandle, globals = Nothing } childMsg sub.effect_model
                     in
-                    ( SubSubSection { sub | effect_model = effect_model }
-                    , Cmd.map (UpdateEffect True) cmd
-                    , []
+                    ( SubSubSection { sub | effect_model = return.value }
+                    , Cmd.map (UpdateEffect True) return.cmd
+                    , return.events
+                        |> send "script" sub.id
                     )
 
                 UpdateEffect sound childMsg ->
                     let
-                        ( effect_model, cmd, event ) =
+                        return =
                             Effect.update { update = subUpdate, handle = subHandle, globals = Nothing } sound childMsg sub.effect_model
                     in
-                    ( SubSubSection { sub | effect_model = effect_model }
-                    , Cmd.map (UpdateEffect sound) cmd
-                    , event
+                    ( SubSubSection { sub | effect_model = return.value }
+                    , Cmd.map (UpdateEffect sound) return.cmd
+                    , return.events
                         |> send "effect" sub.id
                     )
 
@@ -313,12 +315,12 @@ updateScript msg ( section, cmd, events ) =
 
         Just sub ->
             let
-                ( effect_model, cmd2, event ) =
+                return =
                     Effect.updateSub { update = subUpdate, handle = subHandle, globals = Nothing } sub section.effect_model
             in
-            ( { section | effect_model = effect_model }
-            , Cmd.batch [ cmd, Cmd.map (UpdateEffect True) cmd2 ]
-            , event
+            ( { section | effect_model = return.value }
+            , Cmd.batch [ cmd, Cmd.map (UpdateEffect True) return.cmd ]
+            , return.events
                 |> send "effect" section.id
             )
 

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -348,7 +348,7 @@ handle globals topic event section =
             Return.value section
 
 
-ttsReplay : Bool -> Bool -> Maybe Section -> List Event
+ttsReplay : Bool -> Bool -> Maybe Section -> Maybe Event
 ttsReplay sound true section =
     -- replay if possible
     if sound then
@@ -358,16 +358,14 @@ ttsReplay sound true section =
                     (\s ->
                         s.effect_model
                             |> Effect.ttsReplay sound
-                            |> Maybe.map
-                                (List.singleton
-                                    >> send "effect" s.id
-                                )
+                            |> Maybe.map (Event.encode >> Event "effect" s.id)
                     )
-                |> Maybe.withDefault []
 
         else
-            [ Effect.ttsCancel ]
-                |> send "effect" -1
+            Effect.ttsCancel
+                |> Event.encode
+                |> Event "effect" -1
+                |> Just
 
     else
-        []
+        Nothing

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -98,16 +98,16 @@ update globals msg section =
 
         UpdateQuiz childMsg ->
             let
-                ( vector, event, sub ) =
+                result =
                     Quiz.update section.effect_model.javascript childMsg section.quiz_vector
             in
-            ( { section | quiz_vector = vector }
+            ( { section | quiz_vector = result.value }
             , Cmd.none
-            , event
+            , result.events
                 |> List.map Event.encode
                 |> send "quiz"
             )
-                |> updateScript sub
+                |> updateScript result.script
 
         UpdateTask childMsg ->
             let
@@ -220,19 +220,19 @@ subUpdate js msg section =
 
                 UpdateQuiz childMsg ->
                     let
-                        ( vector, events, subCmd ) =
+                        result =
                             Quiz.update js childMsg subsection.quiz_vector
                     in
-                    case subCmd of
+                    case result.script of
                         Just _ ->
                             subUpdate js
                                 (UpdateQuiz childMsg)
-                                (SubSection { subsection | quiz_vector = vector })
+                                (SubSection { subsection | quiz_vector = result.value })
 
                         _ ->
-                            ( SubSection { subsection | quiz_vector = vector }
+                            ( SubSection { subsection | quiz_vector = result.value }
                             , Cmd.none
-                            , events
+                            , result.events
                                 |> List.map Event.encode
                                 |> send "quiz"
                             )

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -14,7 +14,7 @@ import Json.Encode as JE
 import Lia.Definition.Types exposing (Definition)
 import Lia.Markdown.Code.Update as Code
 import Lia.Markdown.Effect.Model as E
-import Lia.Markdown.Effect.Script.Types exposing (Scripts)
+import Lia.Markdown.Effect.Script.Types as Script_ exposing (Scripts)
 import Lia.Markdown.Effect.Script.Update as Script
 import Lia.Markdown.Effect.Update as Effect
 import Lia.Markdown.Footnote.View as Footnote
@@ -41,7 +41,7 @@ type Msg
     | UpdateGallery (Gallery.Msg Msg)
     | FootnoteHide
     | FootnoteShow String
-    | Script (Script.Msg Msg)
+    | Script (Script_.Msg Msg)
     | NoOp
 
 
@@ -315,7 +315,7 @@ subUpdate js msg section =
 
 
 updateScript :
-    Maybe (Script.Msg Msg)
+    Maybe (Script_.Msg Msg)
     -> ( { sec | effect_model : E.Model SubSection }, Cmd Msg, List ( String, JE.Value ) )
     -> ( { sec | effect_model : E.Model SubSection }, Cmd Msg, List ( String, JE.Value ) )
 updateScript msg ( section, cmd, events ) =

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -111,16 +111,16 @@ update globals msg section =
 
         UpdateTask childMsg ->
             let
-                ( vector, event, sub ) =
+                result =
                     Task.update section.effect_model.javascript childMsg section.task_vector
             in
-            ( { section | task_vector = vector }
+            ( { section | task_vector = result.value }
             , Cmd.none
-            , event
+            , result.events
                 |> List.map Event.encode
                 |> send "task"
             )
-                |> updateScript sub
+                |> updateScript result.script
 
         UpdateGallery childMsg ->
             let
@@ -258,19 +258,19 @@ subUpdate js msg section =
 
                 UpdateTask childMsg ->
                     let
-                        ( vector, events, subCmd ) =
+                        result =
                             Task.update js childMsg subsection.task_vector
                     in
-                    case subCmd of
+                    case result.script of
                         Just _ ->
                             subUpdate js
                                 (UpdateTask childMsg)
-                                (SubSection { subsection | task_vector = vector })
+                                (SubSection { subsection | task_vector = result.value })
 
                         _ ->
-                            ( SubSection { subsection | task_vector = vector }
+                            ( SubSection { subsection | task_vector = result.value }
                             , Cmd.none
-                            , events
+                            , result.events
                                 |> List.map Event.encode
                                 |> send "task"
                             )

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -275,7 +275,7 @@ updateScript return =
             in
             { section | effect_model = ret.value }
                 |> Return.replace return
-                |> Return.cmdBatch [ ret.cmd ]
+                |> Return.cmdBatch [ ret.command ]
                 |> Return.events ret.events
 
 

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -135,16 +135,16 @@ update globals msg section =
 
         UpdateSurvey childMsg ->
             let
-                ( vector, event, sub ) =
+                result =
                     Survey.update section.effect_model.javascript childMsg section.survey_vector
             in
-            ( { section | survey_vector = vector }
+            ( { section | survey_vector = result.value }
             , Cmd.none
-            , event
+            , result.events
                 |> List.map Event.encode
                 |> send "survey"
             )
-                |> updateScript sub
+                |> updateScript result.script
 
         UpdateTable childMsg ->
             let
@@ -239,19 +239,19 @@ subUpdate js msg section =
 
                 UpdateSurvey childMsg ->
                     let
-                        ( vector, events, subCmd ) =
+                        result =
                             Survey.update js childMsg subsection.survey_vector
                     in
-                    case subCmd of
+                    case result.script of
                         Just _ ->
                             subUpdate js
                                 (UpdateSurvey childMsg)
-                                (SubSection { subsection | survey_vector = vector })
+                                (SubSection { subsection | survey_vector = result.value })
 
                         _ ->
-                            ( SubSection { subsection | survey_vector = vector }
+                            ( SubSection { subsection | survey_vector = result.value }
                             , Cmd.none
-                            , events
+                            , result.events
                                 |> List.map Event.encode
                                 |> send "survey"
                             )

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -50,11 +50,6 @@ subscriptions _ =
     footnote FootnoteShow
 
 
-send : String -> Int -> List Event -> List Event
-send name id =
-    List.map (Event.encode >> Event name id)
-
-
 update : Definition -> Msg -> Section -> Return Section Msg Msg
 update globals msg section =
     case msg of
@@ -68,8 +63,7 @@ update globals msg section =
                     )
                     sound
                     childMsg
-                |> Return.mapVal (\v -> { section | effect_model = v })
-                |> Return.mapCmd (UpdateEffect sound)
+                |> Return.mapValCmd (\v -> { section | effect_model = v }) (UpdateEffect sound)
                 |> Return.mapEvents "effect" section.id
 
         UpdateCode childMsg ->
@@ -160,8 +154,7 @@ subUpdate js msg section =
                 UpdateEffect sound childMsg ->
                     subsection.effect_model
                         |> Effect.update (subs Nothing) sound childMsg
-                        |> Return.mapVal (\v -> SubSection { subsection | effect_model = v })
-                        |> Return.mapCmd (UpdateEffect sound)
+                        |> Return.mapValCmd (\v -> SubSection { subsection | effect_model = v }) (UpdateEffect sound)
                         |> Return.mapEvents "effect" subsection.id
 
                 UpdateTable childMsg ->
@@ -172,8 +165,7 @@ subUpdate js msg section =
                 UpdateCode childMsg ->
                     subsection.code_model
                         |> Code.update js childMsg
-                        |> Return.mapVal (\v -> SubSection { subsection | code_model = v })
-                        |> Return.mapCmd UpdateCode
+                        |> Return.mapValCmd (\v -> SubSection { subsection | code_model = v }) UpdateCode
                         |> Return.mapEvents "code" subsection.id
 
                 UpdateQuiz childMsg ->
@@ -227,8 +219,7 @@ subUpdate js msg section =
                 Script childMsg ->
                     subsection.effect_model
                         |> Effect.updateSub (subs Nothing) childMsg
-                        |> Return.mapVal (\v -> SubSection { subsection | effect_model = v })
-                        |> Return.mapCmd (UpdateEffect True)
+                        |> Return.mapValCmd (\v -> SubSection { subsection | effect_model = v }) (UpdateEffect True)
                         |> Return.mapEvents "script" subsection.id
 
                 _ ->
@@ -239,15 +230,13 @@ subUpdate js msg section =
                 Script childMsg ->
                     sub.effect_model
                         |> Effect.updateSub (subs Nothing) childMsg
-                        |> Return.mapVal (\v -> SubSubSection { sub | effect_model = v })
-                        |> Return.mapCmd (UpdateEffect True)
+                        |> Return.mapValCmd (\v -> SubSubSection { sub | effect_model = v }) (UpdateEffect True)
                         |> Return.mapEvents "script" sub.id
 
                 UpdateEffect sound childMsg ->
                     sub.effect_model
                         |> Effect.update (subs Nothing) sound childMsg
-                        |> Return.mapVal (\v -> SubSubSection { sub | effect_model = v })
-                        |> Return.mapCmd (UpdateEffect sound)
+                        |> Return.mapValCmd (\v -> SubSubSection { sub | effect_model = v }) (UpdateEffect sound)
                         |> Return.mapEvents "effect" sub.id
 
                 _ ->

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -141,10 +141,10 @@ update globals msg section =
 
         UpdateTable childMsg ->
             let
-                vector =
+                return =
                     Table.update childMsg section.table_vector
             in
-            ( { section | table_vector = vector }
+            ( { section | table_vector = return.value }
             , Cmd.none
             , []
             )
@@ -189,10 +189,10 @@ subUpdate js msg section =
 
                 UpdateTable childMsg ->
                     let
-                        vector =
+                        return =
                             Table.update childMsg subsection.table_vector
                     in
-                    ( SubSection { subsection | table_vector = vector }
+                    ( SubSection { subsection | table_vector = return.value }
                     , Cmd.none
                     , []
                     )

--- a/src/elm/Lia/Markdown/Update.elm
+++ b/src/elm/Lia/Markdown/Update.elm
@@ -84,17 +84,16 @@ update globals msg section =
             )
 
         UpdateCode childMsg ->
-            case Code.update section.effect_model.javascript childMsg section.code_model of
-                ( code_model, [] ) ->
-                    ( { section | code_model = code_model }, Cmd.none, [] )
-
-                ( code_model, events ) ->
-                    ( { section | code_model = code_model }
-                    , Cmd.none
-                    , events
-                        |> List.map Event.encode
-                        |> send "code"
-                    )
+            let
+                result =
+                    Code.update section.effect_model.javascript childMsg section.code_model
+            in
+            ( { section | code_model = result.value }
+            , Cmd.none
+            , result.events
+                |> List.map Event.encode
+                |> send "code"
+            )
 
         UpdateQuiz childMsg ->
             let
@@ -206,17 +205,16 @@ subUpdate js msg section =
                     )
 
                 UpdateCode childMsg ->
-                    case Code.update js childMsg subsection.code_model of
-                        ( code_model, [] ) ->
-                            ( SubSection { subsection | code_model = code_model }, Cmd.none, [] )
-
-                        ( code_model, events ) ->
-                            ( SubSection { subsection | code_model = code_model }
-                            , Cmd.none
-                            , events
-                                |> List.map Event.encode
-                                |> send "code"
-                            )
+                    let
+                        result =
+                            Code.update js childMsg subsection.code_model
+                    in
+                    ( SubSection { subsection | code_model = result.value }
+                    , Cmd.none
+                    , result.events
+                        |> List.map Event.encode
+                        |> send "code"
+                    )
 
                 UpdateQuiz childMsg ->
                     let

--- a/src/elm/Lia/Markdown/View.elm
+++ b/src/elm/Lia/Markdown/View.elm
@@ -13,7 +13,7 @@ import Lia.Markdown.Chart.View as Charts
 import Lia.Markdown.Code.View as Codes
 import Lia.Markdown.Config as Config exposing (Config)
 import Lia.Markdown.Effect.Model as Comments
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script
 import Lia.Markdown.Effect.View as Effect
 import Lia.Markdown.Footnote.Model as Footnotes
 import Lia.Markdown.Footnote.View as Footnote

--- a/src/elm/Lia/Parser/Parser.elm
+++ b/src/elm/Lia/Parser/Parser.elm
@@ -88,8 +88,8 @@ parse_section search_index global sec =
             formatError ms stream |> Err
 
 
-parse_subsection : Maybe Definition -> String -> Result String SubSection
-parse_subsection globals code =
+parse_subsection : Maybe Definition -> Int -> String -> Result String SubSection
+parse_subsection globals id code =
     case
         Combine.runParser
             (Lia.Definition.Parser.parse |> keep Markdown.run)
@@ -104,14 +104,16 @@ parse_subsection globals code =
                 case es of
                     [ Paragraph [] sub ] ->
                         SubSubSection
-                            { body = sub
+                            { id = id
+                            , body = sub
                             , error = Nothing
                             , effect_model = state.effect_model
                             }
 
                     _ ->
                         SubSection
-                            { body = es
+                            { id = id
+                            , body = es
                             , error = Nothing
                             , code_model = state.code_model
                             , task_vector = state.task_vector

--- a/src/elm/Lia/Script.elm
+++ b/src/elm/Lia/Script.elm
@@ -28,6 +28,7 @@ import Json.Encode as JE
 import Lia.Definition.Types exposing (Definition, add_macros)
 import Lia.Json.Encode as Json
 import Lia.Markdown.Inline.Stringify exposing (stringify)
+import Lia.Markdown.Update as Markdown
 import Lia.Model exposing (loadResource)
 import Lia.Parser.Parser as Parser
 import Lia.Section as Section exposing (Sections)
@@ -35,6 +36,7 @@ import Lia.Settings.Update as Settings
 import Lia.Update exposing (Msg(..))
 import Lia.View
 import Port.Event exposing (Event)
+import Return exposing (Return)
 import Session exposing (Screen, Session)
 import Translations
 
@@ -62,7 +64,7 @@ pages =
 this is the first load, then some more initialization has to be done, so use
 `load_first_slide` in this case.
 -}
-load_slide : Session -> Bool -> Int -> Model -> ( Model, Cmd Msg, List Event )
+load_slide : Session -> Bool -> Int -> Model -> Return Model Msg Markdown.Msg
 load_slide session force =
     Load force >> Lia.Update.update session
 
@@ -72,7 +74,7 @@ now be displayed for the first time. It determines the active section, creates
 a `search_index` for local referenced links, and creates connector event, that
 passes a preprocessed version of the course, to the cache used by the backend.
 -}
-load_first_slide : Session -> Model -> ( Model, Cmd Msg, List Event )
+load_first_slide : Session -> Model -> Return Model Msg Markdown.Msg
 load_first_slide session model =
     let
         search_index =
@@ -354,6 +356,6 @@ subscriptions =
 
 {-| Alias for LiaScript update `Lia.Update.update`
 -}
-update : Session -> Msg -> Model -> ( Model, Cmd Msg, List Event )
+update : Session -> Msg -> Model -> Return Model Msg Markdown.Msg
 update =
     Lia.Update.update

--- a/src/elm/Lia/Section.elm
+++ b/src/elm/Lia/Section.elm
@@ -92,7 +92,8 @@ stored permanently. To minimize the requirements, there are actually two types:
 -}
 type SubSection
     = SubSection
-        { body : Markdown.Blocks
+        { id : Int
+        , body : Markdown.Blocks
         , error : Maybe String
         , code_model : Code.Model
         , task_vector : Task.Vector
@@ -105,7 +106,8 @@ type SubSection
         , footnote2show : Maybe String
         }
     | SubSubSection
-        { body : Inlines
+        { id : Int
+        , body : Inlines
         , error : Maybe String
         , effect_model : Effect.Model SubSection
         }

--- a/src/elm/Lia/Settings/Update.elm
+++ b/src/elm/Lia/Settings/Update.elm
@@ -82,7 +82,7 @@ update main msg model =
                     log Nothing { model | sound = not model.sound }
             in
             return
-                |> Return.event (TTS.event return.value.sound)
+                |> Return.batchEvent (TTS.event return.value.sound)
 
         Toggle Light ->
             log Nothing { model | light = not model.light }
@@ -119,7 +119,7 @@ update main msg model =
                             log Nothing { model | sound = False, mode = Textbook }
                     in
                     return
-                        |> Return.event (TTS.event return.value.sound)
+                        |> Return.batchEvent (TTS.event return.value.sound)
 
                 _ ->
                     log Nothing { model | mode = mode }
@@ -145,13 +145,13 @@ update main msg model =
 
         Reset ->
             model
-                |> Return.value
-                |> Return.event (Event "reset" -1 JE.null)
+                |> Return.val
+                |> Return.batchEvent (Event "reset" -1 JE.null)
 
         ShareCourse url ->
             model
-                |> Return.value
-                |> Return.event
+                |> Return.val
+                |> Return.batchEvent
                     ({ title =
                         main
                             |> Maybe.map .title
@@ -167,11 +167,11 @@ update main msg model =
 
         Toggle TranslateWithGoogle ->
             { model | translateWithGoogle = True }
-                |> Return.value
-                |> Return.event (Event "googleTranslate" -1 JE.null)
+                |> Return.val
+                |> Return.batchEvent (Event "googleTranslate" -1 JE.null)
 
         Ignore ->
-            Return.value model
+            Return.val model
 
 
 handle : Event -> Msg
@@ -193,9 +193,9 @@ toggle_sound =
 log : Maybe String -> Settings -> Return Settings Msg sub
 log elementID settings =
     settings
-        |> Return.value
+        |> Return.val
         |> Return.cmd (maybeFocus elementID)
-        |> Return.event (customizeEvent settings)
+        |> Return.batchEvent (customizeEvent settings)
 
 
 customizeEvent : Settings -> Event
@@ -216,7 +216,7 @@ customizeEvent settings =
 
 no_log : Maybe String -> Settings -> Return Settings Msg sub
 no_log elementID =
-    Return.value >> Return.cmd (maybeFocus elementID)
+    Return.val >> Return.cmd (maybeFocus elementID)
 
 
 maybeFocus : Maybe String -> Cmd Msg

--- a/src/elm/Lia/Settings/Update.elm
+++ b/src/elm/Lia/Settings/Update.elm
@@ -16,6 +16,7 @@ import Lia.Utils exposing (focus)
 import Port.Event exposing (Event)
 import Port.Share
 import Port.TTS as TTS
+import Return exposing (Return)
 
 
 type Msg
@@ -40,7 +41,11 @@ type Toggle
     | TranslateWithGoogle
 
 
-update : Maybe { title : String, comment : Inlines } -> Msg -> Settings -> ( Settings, Cmd Msg, List Event )
+update :
+    Maybe { title : String, comment : Inlines }
+    -> Msg
+    -> Settings
+    -> Return Settings Msg sub
 update main msg model =
     case msg of
         Handle event ->
@@ -52,10 +57,7 @@ update main msg model =
 
                 "speak" ->
                     no_log Nothing
-                        { model
-                            | speaking =
-                                TTS.decode event.message == TTS.Start
-                        }
+                        { model | speaking = TTS.decode event.message == TTS.Start }
 
                 _ ->
                     log Nothing model
@@ -76,10 +78,11 @@ update main msg model =
 
         Toggle Sound ->
             let
-                ( new_model, _, events ) =
+                return =
                     log Nothing { model | sound = not model.sound }
             in
-            ( new_model, Cmd.none, TTS.event new_model.sound :: events )
+            return
+                |> Return.event (TTS.event return.value.sound)
 
         Toggle Light ->
             log Nothing { model | light = not model.light }
@@ -112,10 +115,11 @@ update main msg model =
             case mode of
                 Textbook ->
                     let
-                        ( new_model, _, events ) =
+                        return =
                             log Nothing { model | sound = False, mode = Textbook }
                     in
-                    ( new_model, Cmd.none, TTS.event new_model.sound :: events )
+                    return
+                        |> Return.event (TTS.event return.value.sound)
 
                 _ ->
                     log Nothing { model | mode = mode }
@@ -140,33 +144,34 @@ update main msg model =
             log Nothing { model | lang = lang }
 
         Reset ->
-            ( model, Cmd.none, [ Event "reset" -1 JE.null ] )
+            model
+                |> Return.value
+                |> Return.event (Event "reset" -1 JE.null)
 
         ShareCourse url ->
-            ( model
-            , Cmd.none
-            , [ { title =
-                    main
-                        |> Maybe.map .title
-                        |> Maybe.withDefault ""
-                , text =
-                    main
-                        |> Maybe.map (.comment >> stringify)
-                        |> Maybe.withDefault ""
-                , url = url
-                }
-                    |> Port.Share.share
-              ]
-            )
+            model
+                |> Return.value
+                |> Return.event
+                    ({ title =
+                        main
+                            |> Maybe.map .title
+                            |> Maybe.withDefault ""
+                     , text =
+                        main
+                            |> Maybe.map (.comment >> stringify)
+                            |> Maybe.withDefault ""
+                     , url = url
+                     }
+                        |> Port.Share.share
+                    )
 
         Toggle TranslateWithGoogle ->
-            ( { model | translateWithGoogle = True }
-            , Cmd.none
-            , [ Event "googleTranslate" -1 JE.null ]
-            )
+            { model | translateWithGoogle = True }
+                |> Return.value
+                |> Return.event (Event "googleTranslate" -1 JE.null)
 
         Ignore ->
-            ( model, Cmd.none, [] )
+            Return.value model
 
 
 handle : Event -> Msg
@@ -185,12 +190,12 @@ toggle_sound =
     Toggle Sound
 
 
-log : Maybe String -> Settings -> ( Settings, Cmd Msg, List Event )
+log : Maybe String -> Settings -> Return Settings Msg sub
 log elementID settings =
-    ( settings
-    , maybeFocus elementID
-    , [ customizeEvent settings ]
-    )
+    settings
+        |> Return.value
+        |> Return.cmd (maybeFocus elementID)
+        |> Return.event (customizeEvent settings)
 
 
 customizeEvent : Settings -> Event
@@ -209,12 +214,9 @@ customizeEvent settings =
         |> Event "settings" -1
 
 
-no_log : Maybe String -> Settings -> ( Settings, Cmd Msg, List Event )
-no_log elementID settings =
-    ( settings
-    , maybeFocus elementID
-    , []
-    )
+no_log : Maybe String -> Settings -> Return Settings Msg sub
+no_log elementID =
+    Return.value >> Return.cmd (maybeFocus elementID)
 
 
 maybeFocus : Maybe String -> Cmd Msg

--- a/src/elm/Lia/Settings/Update.elm
+++ b/src/elm/Lia/Settings/Update.elm
@@ -8,7 +8,6 @@ module Lia.Settings.Update exposing
     )
 
 import Json.Encode as JE
-import Lia.Markdown.Effect.Parser exposing (comment)
 import Lia.Markdown.Inline.Stringify exposing (stringify)
 import Lia.Markdown.Inline.Types exposing (Inlines)
 import Lia.Settings.Json as Json

--- a/src/elm/Lia/Settings/View.elm
+++ b/src/elm/Lia/Settings/View.elm
@@ -22,7 +22,6 @@ import Html exposing (Html)
 import Html.Attributes as Attr
 import Html.Events exposing (onClick, onInput)
 import Lia.Definition.Types exposing (Definition)
-import Lia.Markdown.Inline.Stringify exposing (stringify)
 import Lia.Markdown.Inline.Types exposing (Inlines)
 import Lia.Markdown.Inline.View exposing (view_inf)
 import Lia.Settings.Types exposing (Action(..), Mode(..), Settings)

--- a/src/elm/Lia/Update.elm
+++ b/src/elm/Lia/Update.elm
@@ -140,8 +140,7 @@ update session msg model =
         UpdateSettings childMsg ->
             model.settings
                 |> Settings.update (Just { title = model.title, comment = model.definition.comment }) childMsg
-                |> Return.mapVal (\v -> { model | settings = v })
-                |> Return.mapCmd UpdateSettings
+                |> Return.mapValCmd (\v -> { model | settings = v }) UpdateSettings
 
         UpdateIndex childMsg ->
             let
@@ -199,8 +198,7 @@ update session msg model =
                         ( Just sec, Ok e ) ->
                             sec
                                 |> Markdown.handle model.definition event.topic e
-                                |> Return.mapVal (\v -> { model | sections = Array.set event.section v model.sections })
-                                |> Return.mapCmd UpdateMarkdown
+                                |> Return.mapValCmd (\v -> { model | sections = Array.set event.section v model.sections }) UpdateMarkdown
 
                         _ ->
                             Return.val model
@@ -212,8 +210,7 @@ update session msg model =
                         |> Return.val
                         |> Return.script sub
                         |> Markdown.updateScript
-                        |> Return.mapVal (\v -> { model | sections = Array.set id v model.sections })
-                        |> Return.mapCmd UpdateMarkdown
+                        |> Return.mapValCmd (\v -> { model | sections = Array.set id v model.sections }) UpdateMarkdown
 
                 _ ->
                     Return.val model
@@ -242,8 +239,7 @@ update session msg model =
                 ( UpdateMarkdown childMsg, Just sec ) ->
                     sec
                         |> Markdown.update model.definition childMsg
-                        |> Return.mapVal (set_active_section model)
-                        |> Return.mapCmd UpdateMarkdown
+                        |> Return.mapValCmd (set_active_section model) UpdateMarkdown
 
                 ( NextSection, Just sec ) ->
                     if (model.settings.mode == Textbook) || not (Effect.has_next sec.effect_model) then
@@ -252,8 +248,7 @@ update session msg model =
                     else
                         sec
                             |> Markdown.nextEffect model.definition model.settings.sound
-                            |> Return.mapVal (set_active_section model)
-                            |> Return.mapCmd UpdateMarkdown
+                            |> Return.mapValCmd (set_active_section model) UpdateMarkdown
 
                 ( PrevSection, Just sec ) ->
                     if (model.settings.mode == Textbook) || not (Effect.has_previous sec.effect_model) then
@@ -262,8 +257,7 @@ update session msg model =
                     else
                         sec
                             |> Markdown.previousEffect model.definition model.settings.sound
-                            |> Return.mapVal (set_active_section model)
-                            |> Return.mapCmd UpdateMarkdown
+                            |> Return.mapValCmd (set_active_section model) UpdateMarkdown
 
                 ( InitSection, Just sec ) ->
                     let
@@ -276,8 +270,9 @@ update session msg model =
                                     Markdown.initEffect model.definition False model.settings.sound sec
                     in
                     return
-                        |> Return.mapVal (set_active_section { model | to_do = [] })
-                        |> Return.mapCmd UpdateMarkdown
+                        |> Return.mapValCmd
+                            (set_active_section { model | to_do = [] })
+                            UpdateMarkdown
                         |> Return.batchEvents (Event "slide" model.section_active JE.null :: model.to_do)
 
                 ( JumpToFragment id, Just sec ) ->
@@ -293,8 +288,7 @@ update session msg model =
                                 Markdown.nextEffect model.definition model.settings.sound { sec | effect_model = { effect | visible = id - 1 } }
                         in
                         return
-                            |> Return.mapVal (set_active_section model)
-                            |> Return.mapCmd UpdateMarkdown
+                            |> Return.mapValCmd (set_active_section model) UpdateMarkdown
 
                 ( TTSReplay bool, sec ) ->
                     case Markdown.ttsReplay model.settings.sound bool sec of

--- a/src/elm/Lia/Update.elm
+++ b/src/elm/Lia/Update.elm
@@ -82,17 +82,6 @@ type Msg
     | Media ( String, Maybe Int, Maybe Int )
 
 
-{-| **@private:** shortcut for generating events for a specific section:
-
-1.  id of the active section
-2.  a list of (`String` topics, `Event` messages)
-
--}
-send : Int -> List ( String, JE.Value ) -> List Event
-send sectionID =
-    List.map (\( name, json ) -> Event name sectionID json)
-
-
 update : Session -> Msg -> Model -> ( Model, Cmd Msg, List Event )
 update session msg model =
     case msg of
@@ -231,7 +220,7 @@ update session msg model =
                             in
                             ( { model | sections = Array.set event.section sec_ model.sections }
                             , Cmd.map UpdateMarkdown cmd_
-                            , send event.section events
+                            , events
                             )
 
                         _ ->
@@ -246,7 +235,7 @@ update session msg model =
                     in
                     ( { model | sections = Array.set id section model.sections }
                     , Cmd.map UpdateMarkdown cmd_
-                    , send id log_
+                    , log_
                     )
 
                 _ ->
@@ -282,7 +271,7 @@ update session msg model =
                     in
                     ( set_active_section model section
                     , Cmd.map UpdateMarkdown cmd_
-                    , send model.section_active log_
+                    , log_
                     )
 
                 ( NextSection, Just sec ) ->
@@ -299,7 +288,7 @@ update session msg model =
                         in
                         ( set_active_section model sec_
                         , Cmd.map UpdateMarkdown cmd_
-                        , send model.section_active log_
+                        , log_
                         )
 
                 ( PrevSection, Just sec ) ->
@@ -313,7 +302,7 @@ update session msg model =
                         in
                         ( set_active_section model sec_
                         , Cmd.map UpdateMarkdown cmd_
-                        , send model.section_active log_
+                        , log_
                         )
 
                 ( InitSection, Just sec ) ->
@@ -329,7 +318,7 @@ update session msg model =
                     ( set_active_section { model | to_do = [] } sec_
                     , Cmd.map UpdateMarkdown cmd_
                     , model.to_do
-                        |> List.append (send model.section_active log_)
+                        |> List.append log_
                         |> (::) (Event "slide" model.section_active JE.null)
                     )
 
@@ -347,14 +336,13 @@ update session msg model =
                         in
                         ( set_active_section model sec_
                         , Cmd.map UpdateMarkdown cmd_
-                        , send model.section_active log_
+                        , log_
                         )
 
                 ( TTSReplay bool, sec ) ->
                     ( model
                     , Cmd.none
                     , Markdown.ttsReplay model.settings.sound bool sec
-                        |> send -1
                     )
 
                 _ ->

--- a/src/elm/Lia/Update.elm
+++ b/src/elm/Lia/Update.elm
@@ -140,7 +140,7 @@ update session msg model =
 
         UpdateSettings childMsg ->
             let
-                ( settings, cmd, events ) =
+                return =
                     Settings.update
                         (Just
                             { title = model.title
@@ -150,9 +150,9 @@ update session msg model =
                         childMsg
                         model.settings
             in
-            ( { model | settings = settings }
-            , Cmd.map UpdateSettings cmd
-            , events
+            ( { model | settings = return.value }
+            , Cmd.map UpdateSettings return.cmd
+            , return.events
             )
 
         UpdateIndex childMsg ->

--- a/src/elm/Lia/Update.elm
+++ b/src/elm/Lia/Update.elm
@@ -13,7 +13,7 @@ import Html.Attributes exposing (width)
 import Json.Decode as JD
 import Json.Encode as JE
 import Lia.Index.Update as Index
-import Lia.Markdown.Effect.Script.Update as Script
+import Lia.Markdown.Effect.Script.Types as Script
 import Lia.Markdown.Effect.Update as Effect
 import Lia.Markdown.Update as Markdown
 import Lia.Model exposing (Model, loadResource)

--- a/src/elm/Return.elm
+++ b/src/elm/Return.elm
@@ -7,6 +7,7 @@ module Return exposing
     , mapCmd
     , mapEvents
     , mapVal
+    , mapValCmd
     , replace
     , script
     , val
@@ -62,6 +63,15 @@ mapCmd fn { value, command, sub, events } =
     }
 
 
+mapValCmd : (modelA -> modelB) -> (msgA -> msgB) -> Return modelA msgA sub -> Return modelB msgB sub
+mapValCmd fnVal fnMsg { value, command, sub, events } =
+    { value = fnVal value
+    , command = Cmd.map fnMsg command
+    , events = events
+    , sub = sub
+    }
+
+
 batchCmd : List (Cmd msg) -> Return model msg sub -> Return model msg sub
 batchCmd cmds r =
     { r | command = Cmd.batch (r.command :: cmds) }
@@ -72,7 +82,7 @@ script s r =
     { r | sub = Just s }
 
 
-mapVal : (model -> model_) -> Return model msg sub -> Return model_ msg sub
+mapVal : (modelA -> modelB) -> Return modelA msg sub -> Return modelB msg sub
 mapVal fn { value, command, events, sub } =
     { value = fn value
     , command = command

--- a/src/elm/Return.elm
+++ b/src/elm/Return.elm
@@ -18,7 +18,7 @@ import Port.Event as Event exposing (Event)
 
 type alias Return model msg sub =
     { value : model
-    , cmd : Cmd msg
+    , command : Cmd msg
     , script : Maybe (Script.Msg sub)
     , events : List Event
     }
@@ -50,13 +50,13 @@ upgrade topic id r =
 
 cmd : Cmd msg -> Return model msg sub -> Return model msg sub
 cmd c r =
-    { r | cmd = c }
+    { r | command = c }
 
 
 cmdMap : (msgA -> msgB) -> Return model msgA sub -> Return model msgB sub
 cmdMap fn r =
     { value = r.value
-    , cmd = Cmd.map fn r.cmd
+    , command = Cmd.map fn r.command
     , script = r.script
     , events = r.events
     }
@@ -64,7 +64,7 @@ cmdMap fn r =
 
 cmdBatch : List (Cmd msg) -> Return model msg sub -> Return model msg sub
 cmdBatch cmds r =
-    { r | cmd = Cmd.batch (r.cmd :: cmds) }
+    { r | command = Cmd.batch (r.command :: cmds) }
 
 
 script : Script.Msg sub -> Return model msg sub -> Return model msg sub
@@ -75,7 +75,7 @@ script s r =
 map : (model -> model_) -> Return model msg sub -> Return model_ msg sub
 map fn r =
     { value = fn r.value
-    , cmd = r.cmd
+    , command = r.command
     , script = r.script
     , events = r.events
     }

--- a/src/elm/Return.elm
+++ b/src/elm/Return.elm
@@ -1,15 +1,18 @@
 module Return exposing
     ( Return
     , cmd
+    , cmdMap
     , event
     , events
     , map
+    , replace
     , script
+    , upgrade
     , value
     )
 
-import Lia.Markdown.Effect.Script.Update as Script
-import Port.Event exposing (Event)
+import Lia.Markdown.Effect.Script.Types as Script
+import Port.Event as Event exposing (Event)
 
 
 type alias Return model msg sub =
@@ -39,9 +42,18 @@ events e r =
     { r | events = List.append r.events e }
 
 
+upgrade : String -> Int -> Return model msg sub -> Return model msg sub
+upgrade topic id r =
+    { r | events = List.map (Event.encode >> Event topic id) r.events }
+
+
 cmd : Cmd msg -> Return model msg sub -> Return model msg sub
 cmd c r =
     { r | cmd = c }
+
+
+cmdMap fn r =
+    { r | cmd = Cmd.map fn r.cmd }
 
 
 script : Script.Msg sub -> Return model msg sub -> Return model msg sub
@@ -56,6 +68,11 @@ map fn r =
     , script = r.script
     , events = r.events
     }
+
+
+replace : Return model_ msg sub -> model -> Return model msg sub
+replace r m =
+    map (always m) r
 
 
 

--- a/src/elm/Return.elm
+++ b/src/elm/Return.elm
@@ -2,6 +2,7 @@ module Return exposing
     ( Return
     , cmd
     , event
+    , events
     , map
     , script
     , value
@@ -28,9 +29,14 @@ value model =
         []
 
 
-event : Event -> Return model cmd sub -> Return model cmd sub
+event : Event -> Return model msg sub -> Return model msg sub
 event e r =
     { r | events = e :: r.events }
+
+
+events : List Event -> Return model msg sub -> Return model msg sub
+events e r =
+    { r | events = List.append r.events e }
 
 
 cmd : Cmd msg -> Return model msg sub -> Return model msg sub

--- a/src/elm/Return.elm
+++ b/src/elm/Return.elm
@@ -1,6 +1,7 @@
 module Return exposing
     ( Return
     , cmd
+    , cmdBatch
     , cmdMap
     , event
     , events
@@ -52,8 +53,18 @@ cmd c r =
     { r | cmd = c }
 
 
+cmdMap : (msgA -> msgB) -> Return model msgA sub -> Return model msgB sub
 cmdMap fn r =
-    { r | cmd = Cmd.map fn r.cmd }
+    { value = r.value
+    , cmd = Cmd.map fn r.cmd
+    , script = r.script
+    , events = r.events
+    }
+
+
+cmdBatch : List (Cmd msg) -> Return model msg sub -> Return model msg sub
+cmdBatch cmds r =
+    { r | cmd = Cmd.batch (r.cmd :: cmds) }
 
 
 script : Script.Msg sub -> Return model msg sub -> Return model msg sub

--- a/src/elm/Return.elm
+++ b/src/elm/Return.elm
@@ -2,6 +2,7 @@ module Return exposing
     ( Return
     , cmd
     , event
+    , map
     , script
     , value
     )
@@ -40,3 +41,16 @@ cmd c r =
 script : Script.Msg sub -> Return model msg sub -> Return model msg sub
 script s r =
     { r | script = Just s }
+
+
+map : (model -> model_) -> Return model msg sub -> Return model_ msg sub
+map fn r =
+    { value = fn r.value
+    , cmd = r.cmd
+    , script = r.script
+    , events = r.events
+    }
+
+
+
+--{ r | value = fn r.value }

--- a/src/elm/Return.elm
+++ b/src/elm/Return.elm
@@ -1,0 +1,42 @@
+module Return exposing
+    ( Return
+    , cmd
+    , event
+    , script
+    , value
+    )
+
+import Lia.Markdown.Effect.Script.Update as Script
+import Port.Event exposing (Event)
+
+
+type alias Return model msg sub =
+    { value : model
+    , cmd : Cmd msg
+    , script : Maybe (Script.Msg sub)
+    , events : List Event
+    }
+
+
+value : model -> Return model cmd sub
+value model =
+    Return
+        model
+        Cmd.none
+        Nothing
+        []
+
+
+event : Event -> Return model cmd sub -> Return model cmd sub
+event e r =
+    { r | events = e :: r.events }
+
+
+cmd : Cmd msg -> Return model msg sub -> Return model msg sub
+cmd c r =
+    { r | cmd = c }
+
+
+script : Script.Msg sub -> Return model msg sub -> Return model msg sub
+script s r =
+    { r | script = Just s }

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -123,11 +123,11 @@ update msg model =
     case msg of
         LiaScript childMsg ->
             let
-                ( lia, cmd, events ) =
+                return =
                     Lia.Script.update model.session childMsg model.lia
             in
-            ( { model | lia = lia }
-            , batch LiaScript cmd events
+            ( { model | lia = return.value }
+            , batch LiaScript return.cmd return.events
             )
 
         Handle event ->
@@ -245,14 +245,14 @@ update msg model =
                                     |> Session.setUrl url
                                     |> Session.setFragment (slide + 1)
 
-                            ( lia, cmd, events ) =
+                            return =
                                 Lia.Script.load_slide session True slide model.lia
                         in
                         ( { model
-                            | lia = lia
+                            | lia = return.value
                             , session = session
                           }
-                        , batch LiaScript cmd events
+                        , batch LiaScript return.cmd return.events
                         )
 
             else
@@ -343,11 +343,11 @@ start model =
         lia =
             model.lia
 
-        ( parsed, cmd, events ) =
+        return =
             Lia.Script.load_first_slide session { lia | section_active = slide }
     in
-    ( { model | state = Running, lia = parsed, session = session }
-    , batch LiaScript cmd events
+    ( { model | state = Running, lia = return.value, session = session }
+    , batch LiaScript return.cmd return.events
     )
 
 
@@ -361,7 +361,7 @@ startWithError model =
         lia =
             model.lia
 
-        ( parsed, cmd, events ) =
+        return =
             Lia.Script.load_first_slide session
                 { lia
                     | section_active = 0
@@ -369,8 +369,8 @@ startWithError model =
                     , definition = Definition.setPersistent False lia.definition
                 }
     in
-    ( { model | lia = parsed, session = session }
-    , batch LiaScript cmd events
+    ( { model | lia = return.value, session = session }
+    , batch LiaScript return.cmd return.events
     )
 
 

--- a/src/elm/Update.elm
+++ b/src/elm/Update.elm
@@ -127,7 +127,7 @@ update msg model =
                     Lia.Script.update model.session childMsg model.lia
             in
             ( { model | lia = return.value }
-            , batch LiaScript return.cmd return.events
+            , batch LiaScript return.command return.events
             )
 
         Handle event ->
@@ -252,7 +252,7 @@ update msg model =
                             | lia = return.value
                             , session = session
                           }
-                        , batch LiaScript return.cmd return.events
+                        , batch LiaScript return.command return.events
                         )
 
             else
@@ -347,7 +347,7 @@ start model =
             Lia.Script.load_first_slide session { lia | section_active = slide }
     in
     ( { model | state = Running, lia = return.value, session = session }
-    , batch LiaScript return.cmd return.events
+    , batch LiaScript return.command return.events
     )
 
 
@@ -370,7 +370,7 @@ startWithError model =
                 }
     in
     ( { model | lia = return.value, session = session }
-    , batch LiaScript return.cmd return.events
+    , batch LiaScript return.command return.events
     )
 
 


### PR DESCRIPTION
Internal routing is now handled consistently with a single Return-type, this contains the model, cmd, events and sub events that are currently used for script-tags which contain some LiaScript results..