### PR TITLE
fix: Terminal resize in code output

### DIFF
--- a/src/scss/03_elements/_elements.code.scss
+++ b/src/scss/03_elements/_elements.code.scss
@@ -64,6 +64,9 @@
     &__output {
       background-color: rgb(var(--lia-anthracite));
       margin: 0;
+      // when this value is changed, also the maxHeight value in
+      //   src/typescript/webcomponents/terminal.ts
+      // has to be changed accordingly
       max-height: 20rem;
       resize: vertical;
       overflow-y: auto;

--- a/src/typescript/webcomponents/terminal.ts
+++ b/src/typescript/webcomponents/terminal.ts
@@ -1,5 +1,12 @@
 import ResizeObserver from 'resize-observer-polyfill'
 
+// currently the maximum height of 20rem is used, whenever this value is changed
+// within the style, then this max value has to changed accordingly in:
+// src/scss/03_elements/_elements.code.scss
+const maxHeight = Math.floor(
+  20 * parseFloat(getComputedStyle(document.documentElement).fontSize)
+)
+
 customElements.define(
   'lia-terminal',
   class extends HTMLElement {
@@ -10,9 +17,15 @@ customElements.define(
       super()
 
       let self = this
-      this.resizeObserver = new ResizeObserver(function (e) {
+      this.resizeObserver = new ResizeObserver(function (
+        entries: ResizeObserverEntry[]
+      ) {
         if (self.style.height) {
           self.height_ = self.style.height
+          self.update()
+          self.dispatchEvent(new CustomEvent('onchangeheight'))
+        } else if (entries?.[0].borderBoxSize?.[0].blockSize >= maxHeight) {
+          self.height_ = maxHeight + 'px'
           self.update()
           self.dispatchEvent(new CustomEvent('onchangeheight'))
         }


### PR DESCRIPTION
If max-height of a terminal window was reached, it was necessary to shrink the window, before it could be increased beyond the max-height, as define in the associated CCS-class. In this fix, the size options are set, when the terminal height has reached the maximum-height.

> Unfortunately, it was not possible to read out the max value from the
> class definition, thus, it has to be set manually, which needs to be
> changed, whenever the class defintion changes.