### PR TITLE
feat: WebComponents as innerHTML

### DIFF
--- a/src/elm/Lia/Markdown/HTML/Types.elm
+++ b/src/elm/Lia/Markdown/HTML/Types.elm
@@ -1,5 +1,6 @@
 module Lia.Markdown.HTML.Types exposing
     ( Node(..)
+    , Type(..)
     , decode
     , encode
     , getContent
@@ -14,6 +15,13 @@ import Lia.Markdown.HTML.Attributes exposing (Parameters)
 type Node content
     = Node String Parameters (List content)
     | InnerHtml String
+
+
+type Type
+    = WebComponent String
+    | HtmlNode String
+    | HtmlVoidNode String
+    | LiaKeep
 
 
 getContent : Node content -> List content


### PR DESCRIPTION
Improves HTML parsing and WebComponents are automatically parsed as strings without the internal analysing. Since WebComponents are mostly used for a specific purpose only, handling internal LiaScript/Markdown elements might be not required. This way it is not required to add `<lia-keep>` around this element.