### PR TITLE
Feat/quiz settings

### DIFF
--- a/src/elm/Lia/Markdown/Parser.elm
+++ b/src/elm/Lia/Markdown/Parser.elm
@@ -48,11 +48,10 @@ import Lia.Markdown.Survey.Parser as Survey
 import Lia.Markdown.Table.Parser as Table
 import Lia.Markdown.Task.Parser as Task
 import Lia.Markdown.Types as Markdown
-import Lia.Parser.Context as Context exposing (Context)
+import Lia.Parser.Context exposing (Context)
 import Lia.Parser.Helper exposing (c_frame, newline, newlines, spaces)
 import Lia.Parser.Indentation as Indent
 import Lia.Parser.Preprocessor exposing (title_tag)
-import Lia.Utils as Utils
 import SvgBob
 
 
@@ -109,44 +108,46 @@ elements =
             |> map Markdown.Survey
             |> andMap Survey.parse
         , md_annotations
-            |> map Tuple.pair
-            |> andMap Context.getSeed
-            |> andThen
-                (\( attr, seed ) ->
-                    { randomize =
-                        if Attributes.isSet "data-randomize" attr then
-                            Just seed
+            |> andThen (\attr -> Quiz.parse attr |> map (Markdown.Quiz attr))
+            {- > map Tuple.pair
+               |> andMap Context.getSeed
+               |> andThen
+                   (\( attr, seed ) ->
+                       { randomize =
+                           if Attributes.isSet "data-randomize" attr then
+                               Just seed
 
-                        else
-                            Nothing
-                    , maxTrials =
-                        attr
-                            |> Attributes.get "data-max-trials"
-                            |> Maybe.andThen String.toInt
-                    , score =
-                        attr
-                            |> Attributes.get "data-max-score"
-                            |> Maybe.andThen String.toFloat
-                    , showResolveAt =
-                        attr
-                            |> Attributes.get "data-show-resolve-button"
-                            |> Maybe.andThen
-                                (\value ->
-                                    case String.toInt value of
-                                        Just int ->
-                                            Just int
+                           else
+                               Nothing
+                       , maxTrials =
+                           attr
+                               |> Attributes.get "data-max-trials"
+                               |> Maybe.andThen String.toInt
+                       , score =
+                           attr
+                               |> Attributes.get "data-max-score"
+                               |> Maybe.andThen String.toFloat
+                       , showResolveAt =
+                           attr
+                               |> Attributes.get "data-show-resolve-button"
+                               |> Maybe.andThen
+                                   (\value ->
+                                       case String.toInt value of
+                                           Just trial ->
+                                               abs trial
 
-                                        Nothing ->
-                                            if Utils.checkFalse value then
-                                                Nothing
+                                           Nothing ->
+                                               if Utils.checkFalse value then
+                                                   0
 
-                                            else
-                                                Just 100000
-                                )
-                    }
-                        |> Quiz.parse
-                        |> map (Markdown.Quiz attr)
-                )
+                                               else
+                                                   100000
+                                   )
+                       }
+                           |> Quiz.parse
+                           |> map (Markdown.Quiz attr)
+                   )
+            -}
             |> andMap solution
         , md_annotations
             |> map Markdown.Task

--- a/src/elm/Lia/Markdown/Parser.elm
+++ b/src/elm/Lia/Markdown/Parser.elm
@@ -108,16 +108,27 @@ elements =
             |> map Markdown.Survey
             |> andMap Survey.parse
         , md_annotations
+            |> map Tuple.pair
+            |> andMap Context.getSeed
             |> andThen
-                (\attr ->
-                    map (Markdown.Quiz attr) <|
+                (\( attr, seed ) ->
+                    { randomize =
                         if Attributes.isSet "data-randomize" attr then
-                            Context.getSeed
-                                |> map Just
-                                |> andThen Quiz.parse
+                            Just seed
 
                         else
-                            Quiz.parse Nothing
+                            Nothing
+                    , maxTrials =
+                        attr
+                            |> Attributes.get "data-max-trials"
+                            |> Maybe.andThen String.toInt
+                    , score =
+                        attr
+                            |> Attributes.get "data-max-score"
+                            |> Maybe.andThen String.toInt
+                    }
+                        |> Quiz.parse
+                        |> map (Markdown.Quiz attr)
                 )
             |> andMap solution
         , md_annotations

--- a/src/elm/Lia/Markdown/Parser.elm
+++ b/src/elm/Lia/Markdown/Parser.elm
@@ -125,7 +125,7 @@ elements =
                     , score =
                         attr
                             |> Attributes.get "data-max-score"
-                            |> Maybe.andThen String.toInt
+                            |> Maybe.andThen String.toFloat
                     }
                         |> Quiz.parse
                         |> map (Markdown.Quiz attr)

--- a/src/elm/Lia/Markdown/Parser.elm
+++ b/src/elm/Lia/Markdown/Parser.elm
@@ -52,6 +52,7 @@ import Lia.Parser.Context as Context exposing (Context)
 import Lia.Parser.Helper exposing (c_frame, newline, newlines, spaces)
 import Lia.Parser.Indentation as Indent
 import Lia.Parser.Preprocessor exposing (title_tag)
+import Lia.Utils as Utils
 import SvgBob
 
 
@@ -128,8 +129,20 @@ elements =
                             |> Maybe.andThen String.toFloat
                     , showResolveAt =
                         attr
-                            |> Attributes.get "data-show-resolve-at"
-                            |> Maybe.andThen String.toInt
+                            |> Attributes.get "data-show-resolve-button"
+                            |> Maybe.andThen
+                                (\value ->
+                                    case String.toInt value of
+                                        Just int ->
+                                            Just int
+
+                                        Nothing ->
+                                            if Utils.checkFalse value then
+                                                Nothing
+
+                                            else
+                                                Just 100000
+                                )
                     }
                         |> Quiz.parse
                         |> map (Markdown.Quiz attr)

--- a/src/elm/Lia/Markdown/Parser.elm
+++ b/src/elm/Lia/Markdown/Parser.elm
@@ -126,6 +126,10 @@ elements =
                         attr
                             |> Attributes.get "data-max-score"
                             |> Maybe.andThen String.toFloat
+                    , showResolveAt =
+                        attr
+                            |> Attributes.get "data-show-resolve-at"
+                            |> Maybe.andThen String.toInt
                     }
                         |> Quiz.parse
                         |> map (Markdown.Quiz attr)

--- a/src/elm/Lia/Markdown/Quiz/Json.elm
+++ b/src/elm/Lia/Markdown/Quiz/Json.elm
@@ -97,15 +97,17 @@ toElement =
                 _ ->
                     JD.succeed Solution.ReSolved
     in
-    JD.map8 Element
+    JD.map5 Element
         (JD.field "solved" JD.int |> JD.andThen solved_decoder)
         (JD.field "state" toState)
         (JD.field "trial" JD.int)
-        (JD.succeed Nothing)
         (JD.field "hint" JD.int)
         (JD.field "error_msg" JD.string)
-        (JD.succeed Nothing)
-        (JD.succeed Nothing)
+        |> JD.andThen
+            (\e ->
+                e Nothing Nothing Nothing Nothing
+                    |> JD.succeed
+            )
 
 
 toState : JD.Decoder State

--- a/src/elm/Lia/Markdown/Quiz/Json.elm
+++ b/src/elm/Lia/Markdown/Quiz/Json.elm
@@ -97,17 +97,20 @@ toElement =
                 _ ->
                     JD.succeed Solution.ReSolved
     in
-    JD.map5 Element
+    JD.map7 Element
         (JD.field "solved" JD.int |> JD.andThen solved_decoder)
         (JD.field "state" toState)
         (JD.field "trial" JD.int)
         (JD.field "hint" JD.int)
         (JD.field "error_msg" JD.string)
-        |> JD.andThen
-            (\e ->
-                e Nothing Nothing Nothing Nothing 0
-                    |> JD.succeed
-            )
+        (JD.succeed Nothing)
+        (JD.succeed
+            { randomize = Nothing
+            , maxTrials = Nothing
+            , score = Nothing
+            , showResolveAt = 0
+            }
+        )
 
 
 toState : JD.Decoder State

--- a/src/elm/Lia/Markdown/Quiz/Json.elm
+++ b/src/elm/Lia/Markdown/Quiz/Json.elm
@@ -97,10 +97,11 @@ toElement =
                 _ ->
                     JD.succeed Solution.ReSolved
     in
-    JD.map7 Element
+    JD.map8 Element
         (JD.field "solved" JD.int |> JD.andThen solved_decoder)
         (JD.field "state" toState)
         (JD.field "trial" JD.int)
+        (JD.succeed Nothing)
         (JD.field "hint" JD.int)
         (JD.field "error_msg" JD.string)
         (JD.succeed Nothing)

--- a/src/elm/Lia/Markdown/Quiz/Json.elm
+++ b/src/elm/Lia/Markdown/Quiz/Json.elm
@@ -105,7 +105,7 @@ toElement =
         (JD.field "error_msg" JD.string)
         |> JD.andThen
             (\e ->
-                e Nothing Nothing Nothing Nothing
+                e Nothing Nothing Nothing Nothing 0
                     |> JD.succeed
             )
 

--- a/src/elm/Lia/Markdown/Quiz/Parser.elm
+++ b/src/elm/Lia/Markdown/Quiz/Parser.elm
@@ -46,7 +46,7 @@ import PseudoRandom
 parse :
     { randomize : Maybe Int
     , maxTrials : Maybe Int
-    , score : Maybe Int
+    , score : Maybe Float
     }
     -> Parser Context Quiz
 parse options =
@@ -115,7 +115,7 @@ hints =
 modify_State :
     { randomize : Maybe Int
     , maxTrials : Maybe Int
-    , score : Maybe Int
+    , score : Maybe Float
     }
     -> Quiz
     -> Parser Context Quiz
@@ -135,6 +135,7 @@ modify_State options q =
                         , randomize =
                             options.randomize
                                 |> Maybe.andThen (randomize q.quiz)
+                        , score = options.score
                         }
                         s.quiz_vector
             }

--- a/src/elm/Lia/Markdown/Quiz/Parser.elm
+++ b/src/elm/Lia/Markdown/Quiz/Parser.elm
@@ -149,11 +149,11 @@ getOptions quiz seed attr =
             |> Maybe.andThen String.toInt
     , score =
         attr
-            |> Attributes.get "data-max-score"
+            |> Attributes.get "data-score"
             |> Maybe.andThen String.toFloat
     , showResolveAt =
         attr
-            |> Attributes.get "data-show-resolve-button"
+            |> Attributes.get "data-solution-button"
             |> Maybe.map
                 (\value ->
                     case String.toInt value of

--- a/src/elm/Lia/Markdown/Quiz/Parser.elm
+++ b/src/elm/Lia/Markdown/Quiz/Parser.elm
@@ -47,6 +47,7 @@ parse :
     { randomize : Maybe Int
     , maxTrials : Maybe Int
     , score : Maybe Float
+    , showResolveAt : Maybe Int
     }
     -> Parser Context Quiz
 parse options =
@@ -116,6 +117,7 @@ modify_State :
     { randomize : Maybe Int
     , maxTrials : Maybe Int
     , score : Maybe Float
+    , showResolveAt : Maybe Int
     }
     -> Quiz
     -> Parser Context Quiz
@@ -136,6 +138,7 @@ modify_State options q =
                             options.randomize
                                 |> Maybe.andThen (randomize q.quiz)
                         , score = options.score
+                        , showResolveAt = Maybe.withDefault 0 options.showResolveAt
                         }
                         s.quiz_vector
             }

--- a/src/elm/Lia/Markdown/Quiz/Types.elm
+++ b/src/elm/Lia/Markdown/Quiz/Types.elm
@@ -33,6 +33,7 @@ type alias Element =
     { solved : Solution
     , state : State
     , trial : Int
+    , maxTrials : Maybe Int
     , hint : Int
     , error_msg : String
     , scriptID : Maybe Int

--- a/src/elm/Lia/Markdown/Quiz/Types.elm
+++ b/src/elm/Lia/Markdown/Quiz/Types.elm
@@ -1,6 +1,7 @@
 module Lia.Markdown.Quiz.Types exposing
     ( Element
     , Hints
+    , Options
     , Quiz
     , State(..)
     , Type(..)
@@ -36,7 +37,12 @@ type alias Element =
     , hint : Int
     , error_msg : String
     , scriptID : Maybe Int
-    , randomize : Maybe (List Int)
+    , opt : Options
+    }
+
+
+type alias Options =
+    { randomize : Maybe (List Int)
     , maxTrials : Maybe Int
     , score : Maybe Float
     , showResolveAt : Int

--- a/src/elm/Lia/Markdown/Quiz/Types.elm
+++ b/src/elm/Lia/Markdown/Quiz/Types.elm
@@ -33,11 +33,12 @@ type alias Element =
     { solved : Solution
     , state : State
     , trial : Int
-    , maxTrials : Maybe Int
     , hint : Int
     , error_msg : String
     , scriptID : Maybe Int
     , randomize : Maybe (List Int)
+    , maxTrials : Maybe Int
+    , score : Maybe Float
     }
 
 

--- a/src/elm/Lia/Markdown/Quiz/Types.elm
+++ b/src/elm/Lia/Markdown/Quiz/Types.elm
@@ -39,6 +39,7 @@ type alias Element =
     , randomize : Maybe (List Int)
     , maxTrials : Maybe Int
     , score : Maybe Float
+    , showResolveAt : Int
     }
 
 

--- a/src/elm/Lia/Markdown/Quiz/Update.elm
+++ b/src/elm/Lia/Markdown/Quiz/Update.elm
@@ -264,7 +264,7 @@ evalEventDecoder json =
 
 isSolved : Maybe Type -> Solution -> Element -> Element
 isSolved solution state e =
-    case ( e.maxTrials, e.solved ) of
+    case ( e.opt.maxTrials, e.solved ) of
         ( Nothing, Solution.Open ) ->
             { e
                 | trial = e.trial + 1
@@ -333,14 +333,11 @@ mergeMap : Element -> Element -> Element
 mergeMap sID body =
     { body
         | scriptID = sID.scriptID
-        , randomize = sID.randomize
-        , maxTrials = sID.maxTrials
-        , showResolveAt = sID.showResolveAt
-        , score = sID.score
+        , opt = sID.opt
         , state =
             -- if the quiz is set to random and is not solved yet,
             -- then it is reset on every load
-            case ( sID.randomize, body.solved ) of
+            case ( sID.opt.randomize, body.solved ) of
                 ( Just _, Solution.Open ) ->
                     reset body.state
 

--- a/src/elm/Lia/Markdown/Quiz/View.elm
+++ b/src/elm/Lia/Markdown/Quiz/View.elm
@@ -287,7 +287,12 @@ viewQuiz config labeledBy state quiz ( attr, body ) =
         body
     , Html.div [ Attr.class "lia-quiz__control" ]
         [ viewMainButton config state.trial state.solved (Check quiz.id quiz.quiz)
-        , viewSolutionButton config state.solved (ShowSolution quiz.id quiz.quiz)
+        , viewSolutionButton
+            { config = config
+            , solution = state.solved
+            , msg = ShowSolution quiz.id quiz.quiz
+            , hidden = state.trial < state.showResolveAt
+            }
         , Translations.quizHint config.lang
             |> viewHintButton quiz.id (quiz.hints /= []) (Solution.Open == state.solved && state.hint < List.length quiz.hints)
         ]
@@ -363,8 +368,8 @@ viewFeedback lang state =
 {-| **private:** Show the solution button only if the quiz has not been solved
 yet.
 -}
-viewSolutionButton : Config sub -> Solution -> Msg sub -> Html (Msg sub)
-viewSolutionButton config solution msg =
+viewSolutionButton : { config : Config sub, hidden : Bool, solution : Solution, msg : Msg sub } -> Html (Msg sub)
+viewSolutionButton { config, hidden, solution, msg } =
     btnIcon
         { title = quizSolution config.lang
         , msg =
@@ -373,10 +378,15 @@ viewSolutionButton config solution msg =
 
             else
                 Nothing
-        , tabbable = True
+        , tabbable = not hidden && solution == Solution.Open
         , icon = "icon-resolve"
         }
-        [ Attr.class "lia-btn--transparent lia-quiz__resolve", A11y_Widget.label (quizLabelSolution config.lang) ]
+        [ Attr.classList
+            [ ( "lia-btn--transparent lia-quiz__resolve", True )
+            , ( "hide", hidden )
+            ]
+        , A11y_Widget.label (quizLabelSolution config.lang)
+        ]
 
 
 {-| **private:** Show the main check-button to compare the current state of the

--- a/src/elm/Lia/Markdown/Quiz/View.elm
+++ b/src/elm/Lia/Markdown/Quiz/View.elm
@@ -230,7 +230,7 @@ viewState config elem quiz =
                     (Solution.toClass ( elem.solved, elem.trial ))
                     q
                 |> Tuple.mapSecond
-                    (shuffle elem.randomize
+                    (shuffle elem.opt.randomize
                         >> List.map (Html.map (Vector_Update quiz.id))
                     )
 
@@ -238,7 +238,7 @@ viewState config elem quiz =
             ( []
             , [ s
                     |> Matrix.view config
-                        (shuffle elem.randomize)
+                        (shuffle elem.opt.randomize)
                         (elem.solved == Solution.Open)
                         (Solution.toClass ( elem.solved, elem.trial ))
                         q
@@ -291,7 +291,7 @@ viewQuiz config labeledBy state quiz ( attr, body ) =
             { config = config
             , solution = state.solved
             , msg = ShowSolution quiz.id quiz.quiz
-            , hidden = state.trial < state.showResolveAt
+            , hidden = state.trial < state.opt.showResolveAt
             }
         , Translations.quizHint config.lang
             |> viewHintButton quiz.id (quiz.hints /= []) (Solution.Open == state.solved && state.hint < List.length quiz.hints)

--- a/src/elm/Lia/Markdown/Survey/Json.elm
+++ b/src/elm/Lia/Markdown/Survey/Json.elm
@@ -131,11 +131,10 @@ toVector =
 
 toElement : JD.Decoder Element
 toElement =
-    JD.map5 Element
+    JD.map4 Element
         (JD.field "submitted" JD.bool)
         (JD.field "state" toState)
         (JD.maybe (JD.field "errorMessage" JD.string))
-        (JD.succeed Nothing)
         (JD.succeed Nothing)
 
 

--- a/src/elm/Lia/Markdown/Survey/Parser.elm
+++ b/src/elm/Lia/Markdown/Survey/Parser.elm
@@ -191,7 +191,6 @@ add_state state id c =
                 , state = state
                 , errorMsg = Nothing
                 , scriptID = id
-                , randomize = Nothing
                 }
                 c.survey_vector
     }

--- a/src/elm/Lia/Markdown/Survey/Types.elm
+++ b/src/elm/Lia/Markdown/Survey/Types.elm
@@ -24,7 +24,6 @@ type alias Element =
     , state : State
     , errorMsg : Maybe String
     , scriptID : Maybe Int
-    , randomize : Maybe (List Int)
     }
 
 

--- a/src/elm/Lia/Markdown/Survey/Update.elm
+++ b/src/elm/Lia/Markdown/Survey/Update.elm
@@ -116,7 +116,7 @@ update sync sectionID scripts msg vector =
                 ( Nothing, _, ( "load", param ) ) ->
                     param
                         |> Json.toVector
-                        |> Result.map (merge vector)
+                        |> Result.map (merge (\sID body -> { body | scriptID = sID.scriptID }) vector)
                         |> Result.withDefault vector
                         |> Return.val
                         |> doSync sync sectionID Nothing
@@ -161,7 +161,7 @@ update sync sectionID scripts msg vector =
                 ( Just "restore", _, ( cmd, param ) ) ->
                     param
                         |> Json.toVector
-                        |> Result.map (merge vector)
+                        |> Result.map (merge (\sID body -> { body | scriptID = sID.scriptID }) vector)
                         |> Result.withDefault vector
                         |> Return.val
                         |> doSync sync sectionID Nothing

--- a/src/elm/Lia/Markdown/Task/Json.elm
+++ b/src/elm/Lia/Markdown/Task/Json.elm
@@ -35,7 +35,6 @@ toVector =
             (\v ->
                 { state = v
                 , scriptID = Nothing
-                , randomize = Nothing
                 }
             )
         |> JD.array

--- a/src/elm/Lia/Markdown/Task/Parser.elm
+++ b/src/elm/Lia/Markdown/Task/Parser.elm
@@ -52,7 +52,6 @@ modify_State ( states, tasks ) =
                     Array.push
                         { state = Array.fromList states
                         , scriptID = m
-                        , randomize = Nothing
                         }
                         s.task_vector
                 , effect_model =
@@ -77,7 +76,6 @@ modify_State ( states, tasks ) =
                                                                 (toString
                                                                     { state = Array.fromList states
                                                                     , scriptID = Nothing
-                                                                    , randomize = Nothing
                                                                     }
                                                                 )
                                                             )

--- a/src/elm/Lia/Markdown/Task/Types.elm
+++ b/src/elm/Lia/Markdown/Task/Types.elm
@@ -30,7 +30,6 @@ type alias Vector =
 type alias Element =
     { state : Array Bool
     , scriptID : Maybe Int
-    , randomize : Maybe (List Int)
     }
 
 

--- a/src/elm/Lia/Markdown/Task/Update.elm
+++ b/src/elm/Lia/Markdown/Task/Update.elm
@@ -11,7 +11,7 @@ import Lia.Markdown.Effect.Script.Update as JS
 import Lia.Markdown.Quiz.Update exposing (init, merge)
 import Lia.Markdown.Task.Json as Json
 import Lia.Markdown.Task.Types exposing (Element, Vector, toString)
-import Return exposing (Return, script)
+import Return exposing (Return)
 import Service.Database
 import Service.Event as Event exposing (Event)
 import Service.Script
@@ -90,7 +90,7 @@ update sectionID scripts msg vector =
                 ( Nothing, _, ( "load", param ) ) ->
                     param
                         |> Json.toVector
-                        |> Result.map (merge vector)
+                        |> Result.map (merge (\sID body -> { body | scriptID = sID.scriptID }) vector)
                         |> Result.withDefault vector
                         |> Return.val
                         |> init execute


### PR DESCRIPTION
Optimizes the quiz-parser and adds the following options to a quiz:

- `data-max-trials`: Defines the number of allowed trials, before the quiz is resolved automatically
- `data-solution-button`: Can be used with the value "true|false|disable|enable" to show or hide the solution-button, additionally it can be based a number that indicates at which trial this button should be shown. "0" will display it immediately, similar to true (used by default), the "1" after the first trial, etc.
- `data-score`: A float value to be used when the project is exported to SCORM to define a custom score, by default it is set to 1.0