### PR TITLE
Fix class for error logging

### DIFF
--- a/src/elm/Lia/Markdown/Code/Log.elm
+++ b/src/elm/Lia/Markdown/Code/Log.elm
@@ -102,7 +102,7 @@ view_message { level, text } =
             viewLog { class = "text-warning", str = text, label = "warning" }
 
         Error ->
-            viewLog { class = "text-info", str = text, label = "error" }
+            viewLog { class = "text-error", str = text, label = "error" }
 
         HTML ->
             Html.div


### PR DESCRIPTION
Errors don't show up as red in the code block output.  I think it's because they're incorrectly assigned the `text-info` class, instead of the `text-error` class.